### PR TITLE
Provide API method to access selected topic names

### DIFF
--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -215,9 +215,6 @@ var Topic = function () {
     }
   }
 
-  /** The presence of selected children determines whether this item is considered selected */
-
-
   _createClass(Topic, [{
     key: 'parentOf',
 
@@ -381,6 +378,14 @@ var Topic = function () {
         this.parent.childWasSelected();
       }
     }
+  }, {
+    key: 'topicName',
+    get: function get() {
+      return this.label.textContent.replace(/(^\s+|\s+$)/g, '');
+    }
+
+    /** The presence of selected children determines whether this item is considered selected */
+
   }, {
     key: 'selectedChildren',
     get: function get() {
@@ -771,28 +776,26 @@ var MillerColumnsSelectedElement = function (_CustomElement3) {
       }
     }
   }, {
-    key: 'update',
+    key: 'selectedTopicNames',
 
 
-    /** Update the UI to show the selected topics */
-    value: function update(taxonomy) {
-      this.taxonomy = taxonomy;
-      var selectedTopics = taxonomy.selectedTopics;
-      // seems simpler to nuke the list and re-build it
-      while (this.list.lastChild) {
-        this.list.removeChild(this.list.lastChild);
+    /** Used as an API into the underlying data represented */
+    value: function selectedTopicNames() {
+      if (!this.taxonomy) {
+        return [];
       }
 
-      if (selectedTopics.length) {
+      return this.taxonomy.selectedTopics.map(function (topic) {
+        var items = [];
         var _iteratorNormalCompletion10 = true;
         var _didIteratorError10 = false;
         var _iteratorError10 = undefined;
 
         try {
-          for (var _iterator10 = selectedTopics[Symbol.iterator](), _step10; !(_iteratorNormalCompletion10 = (_step10 = _iterator10.next()).done); _iteratorNormalCompletion10 = true) {
-            var topic = _step10.value;
+          for (var _iterator10 = topic.parents[Symbol.iterator](), _step10; !(_iteratorNormalCompletion10 = (_step10 = _iterator10.next()).done); _iteratorNormalCompletion10 = true) {
+            var parent = _step10.value;
 
-            this.addSelectedTopic(topic);
+            items.push(parent.topicName);
           }
         } catch (err) {
           _didIteratorError10 = true;
@@ -805,6 +808,49 @@ var MillerColumnsSelectedElement = function (_CustomElement3) {
           } finally {
             if (_didIteratorError10) {
               throw _iteratorError10;
+            }
+          }
+        }
+
+        items.push(topic.topicName);
+        return items;
+      });
+    }
+
+    /** Update the UI to show the selected topics */
+
+  }, {
+    key: 'update',
+    value: function update(taxonomy) {
+      this.taxonomy = taxonomy;
+      var selectedTopics = taxonomy.selectedTopics;
+      // seems simpler to nuke the list and re-build it
+      while (this.list.lastChild) {
+        this.list.removeChild(this.list.lastChild);
+      }
+
+      if (selectedTopics.length) {
+        var _iteratorNormalCompletion11 = true;
+        var _didIteratorError11 = false;
+        var _iteratorError11 = undefined;
+
+        try {
+          for (var _iterator11 = selectedTopics[Symbol.iterator](), _step11; !(_iteratorNormalCompletion11 = (_step11 = _iterator11.next()).done); _iteratorNormalCompletion11 = true) {
+            var topic = _step11.value;
+
+            this.addSelectedTopic(topic);
+          }
+        } catch (err) {
+          _didIteratorError11 = true;
+          _iteratorError11 = err;
+        } finally {
+          try {
+            if (!_iteratorNormalCompletion11 && _iterator11.return) {
+              _iterator11.return();
+            }
+          } finally {
+            if (_didIteratorError11) {
+              throw _iteratorError11;
             }
           }
         }
@@ -831,13 +877,13 @@ var MillerColumnsSelectedElement = function (_CustomElement3) {
       div.className = 'govuk-breadcrumbs';
       var ol = document.createElement('ol');
       ol.className = 'govuk-breadcrumbs__list';
-      var _iteratorNormalCompletion11 = true;
-      var _didIteratorError11 = false;
-      var _iteratorError11 = undefined;
+      var _iteratorNormalCompletion12 = true;
+      var _didIteratorError12 = false;
+      var _iteratorError12 = undefined;
 
       try {
-        for (var _iterator11 = topic.withParents()[Symbol.iterator](), _step11; !(_iteratorNormalCompletion11 = (_step11 = _iterator11.next()).done); _iteratorNormalCompletion11 = true) {
-          var current = _step11.value;
+        for (var _iterator12 = topic.withParents()[Symbol.iterator](), _step12; !(_iteratorNormalCompletion12 = (_step12 = _iterator12.next()).done); _iteratorNormalCompletion12 = true) {
+          var current = _step12.value;
 
           var li = document.createElement('li');
           li.className = 'govuk-breadcrumbs__list-item';
@@ -845,16 +891,16 @@ var MillerColumnsSelectedElement = function (_CustomElement3) {
           ol.appendChild(li);
         }
       } catch (err) {
-        _didIteratorError11 = true;
-        _iteratorError11 = err;
+        _didIteratorError12 = true;
+        _iteratorError12 = err;
       } finally {
         try {
-          if (!_iteratorNormalCompletion11 && _iterator11.return) {
-            _iterator11.return();
+          if (!_iteratorNormalCompletion12 && _iterator12.return) {
+            _iterator12.return();
           }
         } finally {
-          if (_didIteratorError11) {
-            throw _iteratorError11;
+          if (_didIteratorError12) {
+            throw _iteratorError12;
           }
         }
       }

--- a/dist/index.umd.js
+++ b/dist/index.umd.js
@@ -254,9 +254,6 @@
       }
     }
 
-    /** The presence of selected children determines whether this item is considered selected */
-
-
     _createClass(Topic, [{
       key: 'parentOf',
       value: function parentOf(other) {
@@ -401,6 +398,11 @@
         if (this.parent) {
           this.parent.childWasSelected();
         }
+      }
+    }, {
+      key: 'topicName',
+      get: function get() {
+        return this.label.textContent.replace(/(^\s+|\s+$)/g, '');
       }
     }, {
       key: 'selectedChildren',
@@ -758,25 +760,23 @@
         }
       }
     }, {
-      key: 'update',
-      value: function update(taxonomy) {
-        this.taxonomy = taxonomy;
-        var selectedTopics = taxonomy.selectedTopics;
-        // seems simpler to nuke the list and re-build it
-        while (this.list.lastChild) {
-          this.list.removeChild(this.list.lastChild);
+      key: 'selectedTopicNames',
+      value: function selectedTopicNames() {
+        if (!this.taxonomy) {
+          return [];
         }
 
-        if (selectedTopics.length) {
+        return this.taxonomy.selectedTopics.map(function (topic) {
+          var items = [];
           var _iteratorNormalCompletion10 = true;
           var _didIteratorError10 = false;
           var _iteratorError10 = undefined;
 
           try {
-            for (var _iterator10 = selectedTopics[Symbol.iterator](), _step10; !(_iteratorNormalCompletion10 = (_step10 = _iterator10.next()).done); _iteratorNormalCompletion10 = true) {
-              var topic = _step10.value;
+            for (var _iterator10 = topic.parents[Symbol.iterator](), _step10; !(_iteratorNormalCompletion10 = (_step10 = _iterator10.next()).done); _iteratorNormalCompletion10 = true) {
+              var parent = _step10.value;
 
-              this.addSelectedTopic(topic);
+              items.push(parent.topicName);
             }
           } catch (err) {
             _didIteratorError10 = true;
@@ -789,6 +789,46 @@
             } finally {
               if (_didIteratorError10) {
                 throw _iteratorError10;
+              }
+            }
+          }
+
+          items.push(topic.topicName);
+          return items;
+        });
+      }
+    }, {
+      key: 'update',
+      value: function update(taxonomy) {
+        this.taxonomy = taxonomy;
+        var selectedTopics = taxonomy.selectedTopics;
+        // seems simpler to nuke the list and re-build it
+        while (this.list.lastChild) {
+          this.list.removeChild(this.list.lastChild);
+        }
+
+        if (selectedTopics.length) {
+          var _iteratorNormalCompletion11 = true;
+          var _didIteratorError11 = false;
+          var _iteratorError11 = undefined;
+
+          try {
+            for (var _iterator11 = selectedTopics[Symbol.iterator](), _step11; !(_iteratorNormalCompletion11 = (_step11 = _iterator11.next()).done); _iteratorNormalCompletion11 = true) {
+              var topic = _step11.value;
+
+              this.addSelectedTopic(topic);
+            }
+          } catch (err) {
+            _didIteratorError11 = true;
+            _iteratorError11 = err;
+          } finally {
+            try {
+              if (!_iteratorNormalCompletion11 && _iterator11.return) {
+                _iterator11.return();
+              }
+            } finally {
+              if (_didIteratorError11) {
+                throw _iteratorError11;
               }
             }
           }
@@ -815,13 +855,13 @@
         div.className = 'govuk-breadcrumbs';
         var ol = document.createElement('ol');
         ol.className = 'govuk-breadcrumbs__list';
-        var _iteratorNormalCompletion11 = true;
-        var _didIteratorError11 = false;
-        var _iteratorError11 = undefined;
+        var _iteratorNormalCompletion12 = true;
+        var _didIteratorError12 = false;
+        var _iteratorError12 = undefined;
 
         try {
-          for (var _iterator11 = topic.withParents()[Symbol.iterator](), _step11; !(_iteratorNormalCompletion11 = (_step11 = _iterator11.next()).done); _iteratorNormalCompletion11 = true) {
-            var current = _step11.value;
+          for (var _iterator12 = topic.withParents()[Symbol.iterator](), _step12; !(_iteratorNormalCompletion12 = (_step12 = _iterator12.next()).done); _iteratorNormalCompletion12 = true) {
+            var current = _step12.value;
 
             var li = document.createElement('li');
             li.className = 'govuk-breadcrumbs__list-item';
@@ -829,16 +869,16 @@
             ol.appendChild(li);
           }
         } catch (err) {
-          _didIteratorError11 = true;
-          _iteratorError11 = err;
+          _didIteratorError12 = true;
+          _iteratorError12 = err;
         } finally {
           try {
-            if (!_iteratorNormalCompletion11 && _iterator11.return) {
-              _iterator11.return();
+            if (!_iteratorNormalCompletion12 && _iterator12.return) {
+              _iterator12.return();
             }
           } finally {
-            if (_didIteratorError11) {
-              throw _iteratorError11;
+            if (_didIteratorError12) {
+              throw _iteratorError12;
             }
           }
         }

--- a/index.js
+++ b/index.js
@@ -138,6 +138,10 @@ class Topic {
     }
   }
 
+  get topicName(): string {
+    return this.label.textContent.replace(/(^\s+|\s+$)/g, '')
+  }
+
   /** The presence of selected children determines whether this item is considered selected */
   get selectedChildren(): Array<Topic> {
     return this.children.reduce((memo, topic) => {
@@ -477,6 +481,22 @@ class MillerColumnsSelectedElement extends HTMLElement {
   get millerColumnsElement(): ?MillerColumnsElement {
     const millerColumns = document.getElementById(this.getAttribute('for') || '')
     return millerColumns instanceof MillerColumnsElement ? millerColumns : null
+  }
+
+  /** Used as an API into the underlying data represented */
+  selectedTopicNames(): Array<Array<string>> {
+    if (!this.taxonomy) {
+      return []
+    }
+
+    return this.taxonomy.selectedTopics.map(topic => {
+      const items = []
+      for (const parent of topic.parents) {
+        items.push(parent.topicName)
+      }
+      items.push(topic.topicName)
+      return items
+    })
   }
 
   /** Update the UI to show the selected topics */

--- a/test/test.js
+++ b/test/test.js
@@ -21,7 +21,7 @@ describe('miller-columns', function() {
           <li>
              <div class="govuk-checkboxes__item">
                 <input type="checkbox" id="topic-206b7f3a-49b5-476f-af0f-fd27e2a68473" class="govuk-checkboxes__input" name="topics[]" value="206b7f3a-49b5-476f-af0f-fd27e2a68473" tabindex="-1">
-                <label for="topic-206b7f3a-49b5-476f-af0f-fd27e2a68473" class="govuk-label govuk-checkboxes__label">
+                <label for="topic-206b7f3a-49b5-476f-af0f-fd27e2a68473" class="govuk-label govuk-checkboxes__label" id="parenting-childcare-and-childrens-services">
                 Parenting, childcare and children's services
                 </label>
              </div>
@@ -29,7 +29,7 @@ describe('miller-columns', function() {
                 <li>
                    <div class="govuk-checkboxes__item">
                       <input type="checkbox" id="topic-1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" class="govuk-checkboxes__input" name="topics[]" value="1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" tabindex="-1">
-                      <label for="topic-1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" class="govuk-label govuk-checkboxes__label">
+                      <label for="topic-1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" class="govuk-label govuk-checkboxes__label" id="divorce-separation-and-legal-issues">
                       Divorce, separation and legal issues
                       </label>
                    </div>
@@ -37,7 +37,7 @@ describe('miller-columns', function() {
                       <li>
                          <div class="govuk-checkboxes__item">
                             <input type="checkbox" id="topic-9ed56732-8600-493e-8467-295233529718" class="govuk-checkboxes__input" name="topics[]" value="9ed56732-8600-493e-8467-295233529718" tabindex="-1">
-                            <label for="topic-9ed56732-8600-493e-8467-295233529718" class="govuk-label govuk-checkboxes__label">
+                            <label for="topic-9ed56732-8600-493e-8467-295233529718" class="govuk-label govuk-checkboxes__label" id="child-custody">
                             Child custody
                             </label>
                          </div>
@@ -45,7 +45,7 @@ describe('miller-columns', function() {
                       <li>
                          <div class="govuk-checkboxes__item">
                             <input type="checkbox" id="topic-237b2e72-c465-42fe-9293-8b6af21713c0" class="govuk-checkboxes__input" name="topics[]" value="237b2e72-c465-42fe-9293-8b6af21713c0" tabindex="-1">
-                            <label for="topic-237b2e72-c465-42fe-9293-8b6af21713c0" class="govuk-label govuk-checkboxes__label">
+                            <label for="topic-237b2e72-c465-42fe-9293-8b6af21713c0" class="govuk-label govuk-checkboxes__label" id="disagreements-about-parentage">
                             Disagreements about parentage
                             </label>
                          </div>
@@ -173,6 +173,29 @@ describe('miller-columns', function() {
       assert.equal(selectedItems.childNodes.length, 2)
       assert.isTrue(selectedItems.textContent.includes(firstLabelL2.textContent))
       assert.isTrue(selectedItems.textContent.includes(secondLabelL2.textContent))
+    })
+
+    it('provides an API to access a list of selected items by name', function() {
+      const elements = [
+        document.getElementById('parenting-childcare-and-childrens-services'),
+        document.getElementById('divorce-separation-and-legal-issues'),
+        document.getElementById('child-custody'),
+        document.getElementById('disagreements-about-parentage')
+      ]
+
+      for (const element of elements) {
+        element.closest('li').click()
+      }
+
+      const millerColumnsSelected = document.querySelector('miller-columns-selected')
+      assert.deepEqual(millerColumnsSelected.selectedTopicNames(), [
+        ["Parenting, childcare and children's services", 'Divorce, separation and legal issues', 'Child custody'],
+        [
+          "Parenting, childcare and children's services",
+          'Divorce, separation and legal issues',
+          'Disagreements about parentage'
+        ]
+      ])
     })
   })
 


### PR DESCRIPTION
Trello: https://trello.com/c/BxMYIA6R/562-look-at-creating-custom-event-for-capturing-user-taxonomy-selections-on-formsubmit

This provides a method on the <miller-column-selected> element of
selectedTopicNames which returns lists of the topic names that are
selected.

This is intended to be used by Google Tag Manager so that tags that are
selected can be sent as names rather than ids.

Example:

If we have topics like so:

```
Grandparent of A | Parent of A | A
Parent of B | B | Child of B
Grandparent of C | Parent of C | C
```

and topics B and A are selected

a call to selectedTopicNames would return

```
[
  ['Grandparent of A', 'Parent of A', 'A'],
  ['Parent of B', 'B']
]
```