### PR TITLE
Fix narrow threshold

### DIFF
--- a/index.js
+++ b/index.js
@@ -278,6 +278,7 @@ class MillerColumnsElement extends HTMLElement {
     this.classNames = {
       column: 'miller-columns__column',
       columnCollapse: 'miller-columns__column--collapse',
+      columnMedium: 'miller-columns__column--medium',
       columnNarrow: 'miller-columns__column--narrow',
       item: 'miller-columns__item',
       itemParent: 'miller-columns__item--parent',
@@ -428,7 +429,8 @@ class MillerColumnsElement extends HTMLElement {
     const columnsToShow = this.columnsForActiveTopic(activeTopic)
     const narrowThreshold = Math.max(3, columnsToShow.length - 1)
     const showNarrow = columnsToShow.length > narrowThreshold
-    const {columnCollapse: collapseClass, columnNarrow: narrowClass} = this.classNames
+    const showMedium = showNarrow && narrowThreshold === 3
+    const {columnCollapse: collapseClass, columnNarrow: narrowClass, columnMedium: mediumClass} = this.classNames
 
     for (const item of allColumns) {
       if (!item) {
@@ -437,7 +439,12 @@ class MillerColumnsElement extends HTMLElement {
 
       // we always want to show the root column
       if (item.dataset.root === 'true') {
-        showNarrow ? item.classList.add(narrowClass) : item.classList.remove(narrowClass)
+        item.classList.remove(narrowClass, mediumClass)
+        if (showMedium) {
+          item.classList.add(mediumClass)
+        } else if (showNarrow) {
+          item.classList.add(narrowClass)
+        }
         continue
       }
 
@@ -448,11 +455,15 @@ class MillerColumnsElement extends HTMLElement {
         item.classList.add(collapseClass)
       } else if (showNarrow && index < narrowThreshold) {
         // show this column but narrow
-        item.classList.remove(collapseClass)
-        item.classList.add(narrowClass)
+        item.classList.remove(collapseClass, narrowClass, mediumClass)
+        if (showMedium) {
+          item.classList.add(mediumClass)
+        } else if (showNarrow) {
+          item.classList.add(narrowClass)
+        }
       } else {
         // show this column in all it's glory
-        item.classList.remove(collapseClass, narrowClass)
+        item.classList.remove(collapseClass, narrowClass, mediumClass)
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -426,7 +426,7 @@ class MillerColumnsElement extends HTMLElement {
   showCurrentColumns(activeTopic: ?Topic) {
     const allColumns = nodesToArray(this.getElementsByClassName(this.classNames.column))
     const columnsToShow = this.columnsForActiveTopic(activeTopic)
-    const narrowThreshold = 3
+    const narrowThreshold = Math.max(3, columnsToShow.length - 1)
     const showNarrow = columnsToShow.length > narrowThreshold
     const {columnCollapse: collapseClass, columnNarrow: narrowClass} = this.classNames
 

--- a/main.scss
+++ b/main.scss
@@ -39,7 +39,7 @@ $transition-time: 400ms;
 }
 
 .miller-columns__column--narrow {
-  width: 16%;
+  width: 16.6%;
   overflow-x: hidden;
 
   .miller-columns__item,

--- a/main.scss
+++ b/main.scss
@@ -52,6 +52,20 @@ $transition-time: 400ms;
   }
 }
 
+.miller-columns__column--medium {
+  width: 22.2%;
+  overflow-x: hidden;
+
+  .miller-columns__item,
+  .miller-columns__item label {
+    white-space: nowrap;
+  }
+
+  .miller-columns__item--parent:after {
+    display: none;
+  }
+}
+
 .miller-columns__column--collapse {
   display: none;
 }


### PR DESCRIPTION
This PR fixes an issue with the miller columns where columns are not shifting to the left after the 3rd level.

### Before
<img width="1440" alt="Screen Shot 2019-06-04 at 16 57 53" src="https://user-images.githubusercontent.com/788096/58894922-c3629d80-86ea-11e9-831a-d15357d95840.png">

### After
<img width="1440" alt="Screen Shot 2019-06-04 at 16 56 12" src="https://user-images.githubusercontent.com/788096/58894931-c78ebb00-86ea-11e9-93fd-edca68bef1f6.png">

#### Note
The update dependency commit is prevent this from failing CI but will be dropped before merge as it's captured in https://github.com/alphagov/miller-columns-element/pull/11/commits/4ecaab49fefcdb8fb8b6ea99064ec0027dbd8ad8.

[Trello card](https://trello.com/c/qECJohOD)