### PR TITLE
Trigger remove topic event

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,20 @@ function nodesToArray(nodes: NodeList<HTMLElement> | HTMLCollection<HTMLElement>
   return Array.prototype.slice.call(nodes)
 }
 
+function triggerEvent(element: HTMLElement, eventName: string, detail: Object) {
+  const params = {bubbles: true, cancelable: true, detail: detail || null}
+  let event
+
+  if (typeof window.CustomEvent === 'function') {
+    event = new window.CustomEvent(eventName, params)
+  } else {
+    event = document.createEvent('CustomEvent')
+    event.initCustomEvent(eventName, params.bubbles, params.cancelable, params.detail)
+  }
+
+  element.dispatchEvent(event)
+}
+
 /**
  * This models the taxonomy shown in the miller columns and the current state
  * of it.
@@ -577,6 +591,7 @@ class MillerColumnsSelectedElement extends HTMLElement {
     button.textContent = 'Remove topic'
     button.setAttribute('type', 'button')
     button.addEventListener('click', () => {
+      triggerEvent(button, 'remove-topic', topic)
       if (this.taxonomy) {
         this.taxonomy.removeTopic(topic)
       }

--- a/test/test.js
+++ b/test/test.js
@@ -155,6 +155,11 @@ describe('miller-columns', function() {
 
       const selectedItems = document.querySelector('#selected-items')
       assert.equal(selectedItems.textContent, 'No selected topics')
+
+      const millerColumnsSelected = document.querySelector('miller-columns-selected')
+      millerColumnsSelected.addEventListener('remove-topic', function(e) {
+        assert.equal(e.detail.topicName, "Parenting, childcare and children's services")
+      })
     })
 
     it('creates entries of selected item for adjacent topics', function() {


### PR DESCRIPTION
Trigger an event when removing topics from the MillerColumnsSelectedElement, so it can be tracked with analytics. It uses a `triggerEvent` function which acts as a polyfill for browsers that don't support CustomEvents..

It can be used/tested as shown in the example below:

```js
var millerColumnsSelected = document.querySelector('.miller-columns-selected')

millerColumnsSelected.addEventListener('remove-topic', function(e){
  console.log(e.detail.topicNames.join(' > '))
})
```

[Trello card](https://trello.com/c/tAXP6pf1)