### PR TITLE
Trigger click topic event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ## Unreleased
 
 - Scope pointer events on checkboxes to the miller-columns element (PR #14)
+- Trigger remove-topic event on MillerColumnsSelectedElement (PR #15)
+- Trigger click-topic event on MillerColumnsElement (PR #16)
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Scope pointer events on checkboxes to the miller-columns element (PR #14)
 - Trigger remove-topic event on MillerColumnsSelectedElement (PR #15)
-- Trigger click-topic event on MillerColumnsElement (PR #16)
+- Trigger click event on checkboxes when selecting an item in the MillerColumnsElement (PR #16)
 
 ## 0.1.0
 

--- a/index.js
+++ b/index.js
@@ -77,7 +77,6 @@ class Taxonomy {
       topic.select()
       this.active = topic
     }
-    topic.checkbox.dispatchEvent(new Event('click'))
     this.millerColumns.update()
   }
 
@@ -357,13 +356,21 @@ class MillerColumnsElement extends HTMLElement {
   /** Sets up the event handling for a list item and a topic */
   attachEvents(trigger: HTMLElement, topic: Topic) {
     trigger.tabIndex = 0
-    trigger.addEventListener('click', () => this.taxonomy.topicClicked(topic), false)
+    trigger.addEventListener(
+      'click',
+      () => {
+        this.taxonomy.topicClicked(topic)
+        topic.checkbox.dispatchEvent(new Event('click'))
+      },
+      false
+    )
     trigger.addEventListener(
       'keydown',
       (event: KeyboardEvent) => {
         if ([' ', 'Enter'].indexOf(event.key) !== -1) {
           event.preventDefault()
           this.taxonomy.topicClicked(topic)
+          topic.checkbox.dispatchEvent(new Event('click'))
         }
       },
       false

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ class Taxonomy {
       topic.select()
       this.active = topic
     }
-    triggerEvent(this.millerColumns, 'click-topic', topic)
+    topic.checkbox.dispatchEvent(new Event('click'))
     this.millerColumns.update()
   }
 

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ class Taxonomy {
       topic.select()
       this.active = topic
     }
-
+    triggerEvent(this.millerColumns, 'click-topic', topic)
     this.millerColumns.update()
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -99,9 +99,9 @@ describe('miller-columns', function() {
       assert.isTrue(firstItem.classList.contains('miller-columns__item--active'))
       assert.isTrue(firstItem.querySelector('input').checked)
 
-      const millerColumns = document.querySelector('miller-columns')
-      millerColumns.addEventListener('click-topic', function(e) {
-        assert.equal(e.detail.topicName, "Parenting, childcare and children's services")
+      const firstItemCheckbox = firstItem.querySelector('input')
+      firstItemCheckbox.addEventListener('click', function(e) {
+        assert.deepEqual(e.target, firstItemCheckbox)
       })
     })
 

--- a/test/test.js
+++ b/test/test.js
@@ -94,15 +94,15 @@ describe('miller-columns', function() {
 
     it('mark selected item as active', function() {
       const firstItem = document.querySelector('ul li')
-      firstItem.click()
-
-      assert.isTrue(firstItem.classList.contains('miller-columns__item--active'))
-      assert.isTrue(firstItem.querySelector('input').checked)
-
       const firstItemCheckbox = firstItem.querySelector('input')
       firstItemCheckbox.addEventListener('click', function(e) {
         assert.deepEqual(e.target, firstItemCheckbox)
       })
+
+      firstItem.click()
+
+      assert.isTrue(firstItem.classList.contains('miller-columns__item--active'))
+      assert.isTrue(firstItem.querySelector('input').checked)
     })
 
     it('show the child list for active list item', function() {
@@ -153,6 +153,10 @@ describe('miller-columns', function() {
 
     it('removes a chain from stored selected items', function() {
       const firstItemL1 = document.querySelector('ul li')
+      const millerColumnsSelected = document.querySelector('miller-columns-selected')
+      millerColumnsSelected.addEventListener('remove-topic', function(e) {
+        assert.equal(e.detail.topicName, "Parenting, childcare and children's services")
+      })
 
       firstItemL1.click()
 
@@ -161,11 +165,6 @@ describe('miller-columns', function() {
 
       const selectedItems = document.querySelector('#selected-items')
       assert.equal(selectedItems.textContent, 'No selected topics')
-
-      const millerColumnsSelected = document.querySelector('miller-columns-selected')
-      millerColumnsSelected.addEventListener('remove-topic', function(e) {
-        assert.equal(e.detail.topicName, "Parenting, childcare and children's services")
-      })
     })
 
     it('creates entries of selected item for adjacent topics', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -92,11 +92,17 @@ describe('miller-columns', function() {
       assert.isTrue(firstItem.classList.contains('miller-columns__item--parent'))
     })
 
-    it('styles active items', function() {
+    it('mark selected item as active', function() {
       const firstItem = document.querySelector('ul li')
       firstItem.click()
+
       assert.isTrue(firstItem.classList.contains('miller-columns__item--active'))
       assert.isTrue(firstItem.querySelector('input').checked)
+
+      const millerColumns = document.querySelector('miller-columns')
+      millerColumns.addEventListener('click-topic', function(e) {
+        assert.equal(e.detail.topicName, "Parenting, childcare and children's services")
+      })
     })
 
     it('show the child list for active list item', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,13 @@ describe('miller-columns', function() {
   })
 
   describe('after tree insertion', function() {
+    function pressKey(key, element) {
+      const event = document.createEvent('Event')
+      event.initEvent('keydown', true, true)
+      event.key = key
+      element.dispatchEvent(event)
+    }
+
     beforeEach(function() {
       const container = document.createElement('div')
       container.innerHTML = `
@@ -92,7 +99,7 @@ describe('miller-columns', function() {
       assert.isTrue(firstItem.classList.contains('miller-columns__item--parent'))
     })
 
-    it('mark selected item as active', function() {
+    it('mark selected item as active when clicked', function() {
       const firstItem = document.querySelector('ul li')
       const firstItemCheckbox = firstItem.querySelector('input')
       firstItemCheckbox.addEventListener('click', function(e) {
@@ -100,6 +107,34 @@ describe('miller-columns', function() {
       })
 
       firstItem.click()
+
+      assert.isTrue(firstItem.classList.contains('miller-columns__item--active'))
+      assert.isTrue(firstItem.querySelector('input').checked)
+    })
+
+    it('mark selected item as active when pressing Enter', function() {
+      const firstItem = document.querySelector('ul li')
+      const firstItemCheckbox = firstItem.querySelector('input')
+      firstItemCheckbox.addEventListener('keydown', function(e) {
+        assert.deepEqual(e.target, firstItemCheckbox)
+      })
+
+      firstItem.focus()
+      pressKey('Enter', firstItemCheckbox)
+
+      assert.isTrue(firstItem.classList.contains('miller-columns__item--active'))
+      assert.isTrue(firstItem.querySelector('input').checked)
+    })
+
+    it('mark selected item as active when pressing Space', function() {
+      const firstItem = document.querySelector('ul li')
+      const firstItemCheckbox = firstItem.querySelector('input')
+      firstItemCheckbox.addEventListener('keydown', function(e) {
+        assert.deepEqual(e.target, firstItemCheckbox)
+      })
+
+      firstItem.focus()
+      pressKey(' ', firstItemCheckbox)
 
       assert.isTrue(firstItem.classList.contains('miller-columns__item--active'))
       assert.isTrue(firstItem.querySelector('input').checked)


### PR DESCRIPTION
Trigger an event when clicking a topic item in the `MillerColumnsElement` so it can be tracked with analytics.

It can be used/tested as shown in the example below (updated after review):

```diff
-var millerColumns = document.querySelector('.miller-columns')
-
-millerColumns.addEventListener('click-topic', function(e){
-  console.log(e.detail.topicNames.join(' > '), e.detail.selected)
-})

+var millerColumnsInput = document.querySelector('.miller-columns input')
+
+millerColumnsInput.addEventListener('click', function(e){
+  console.log(e.target)
+})

```

[Trello card](https://trello.com/c/tAXP6pf1)