### PR TITLE
Remove selectedTopicNames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Trigger click event on checkboxes when selecting an item in the MillerColumnsElement (PR #16)
+- BREAKING: Remove `selectedTopicNames` as we don't need this API method for analytics anymore (PR #17)
+
 ## 0.1.1
 
 - Scope pointer events on checkboxes to the miller-columns element (PR #14)
 - Trigger remove-topic event on MillerColumnsSelectedElement (PR #15)
-- Trigger click event on checkboxes when selecting an item in the MillerColumnsElement (PR #16)
 
 ## 0.1.0
 

--- a/index.js
+++ b/index.js
@@ -539,15 +539,6 @@ class MillerColumnsSelectedElement extends HTMLElement {
     return millerColumns instanceof MillerColumnsElement ? millerColumns : null
   }
 
-  /** Used as an API into the underlying data represented */
-  selectedTopicNames(): Array<Array<string>> {
-    if (!this.taxonomy) {
-      return []
-    }
-
-    return this.taxonomy.selectedTopics.map(topic => topic.topicNames)
-  }
-
   /** Update the UI to show the selected topics */
   update(taxonomy: Taxonomy) {
     this.taxonomy = taxonomy

--- a/test/test.js
+++ b/test/test.js
@@ -220,29 +220,6 @@ describe('miller-columns', function() {
       assert.isTrue(selectedItems.textContent.includes(secondLabelL2.textContent))
     })
 
-    it('provides an API to access a list of selected items by name', function() {
-      const elements = [
-        document.getElementById('parenting-childcare-and-childrens-services'),
-        document.getElementById('divorce-separation-and-legal-issues'),
-        document.getElementById('child-custody'),
-        document.getElementById('disagreements-about-parentage')
-      ]
-
-      for (const element of elements) {
-        element.closest('li').click()
-      }
-
-      const millerColumnsSelected = document.querySelector('miller-columns-selected')
-      assert.deepEqual(millerColumnsSelected.selectedTopicNames(), [
-        ["Parenting, childcare and children's services", 'Divorce, separation and legal issues', 'Child custody'],
-        [
-          "Parenting, childcare and children's services",
-          'Divorce, separation and legal issues',
-          'Disagreements about parentage'
-        ]
-      ])
-    })
-
     it('provides an API to access the breadcrumb trail of a topic', function() {
       const firstItemL2 = document.querySelector('miller-columns').taxonomy.topics[0].children[0]
       assert.deepEqual(firstItemL2.topicNames, [


### PR DESCRIPTION
Remove [`selectedTopicNames`](https://github.com/alphagov/miller-columns-element/pull/7) as we don't need this API method for analytics anymore. We're moving into tracking individual selection of topics instead.

[Trello card](https://trello.com/c/tAXP6pf1/948-analytics-for-topics)