### PR TITLE
Update to govuk-frontend 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Update miller-columns-element to `govuk-frontend` 3.2 (PR #23)
+
 ## 1.0.0
 
 - Trigger click event on checkboxes when selecting an item in the MillerColumnsElement (PR #16)

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -18,6 +18,20 @@ function nodesToArray(nodes) {
   return Array.prototype.slice.call(nodes);
 }
 
+function triggerEvent(element, eventName, detail) {
+  var params = { bubbles: true, cancelable: true, detail: detail || null };
+  var event = void 0;
+
+  if (typeof window.CustomEvent === 'function') {
+    event = new window.CustomEvent(eventName, params);
+  } else {
+    event = document.createEvent('CustomEvent');
+    event.initCustomEvent(eventName, params.bubbles, params.cancelable, params.detail);
+  }
+
+  element.dispatchEvent(event);
+}
+
 /**
  * This models the taxonomy shown in the miller columns and the current state
  * of it.
@@ -66,7 +80,6 @@ var Taxonomy = function () {
         topic.select();
         this.active = topic;
       }
-
       this.millerColumns.update();
     }
 
@@ -570,12 +583,14 @@ var MillerColumnsElement = function (_CustomElement2) {
 
       trigger.tabIndex = 0;
       trigger.addEventListener('click', function () {
-        return _this2.taxonomy.topicClicked(topic);
+        _this2.taxonomy.topicClicked(topic);
+        topic.checkbox.dispatchEvent(new Event('click'));
       }, false);
       trigger.addEventListener('keydown', function (event) {
         if ([' ', 'Enter'].indexOf(event.key) !== -1) {
           event.preventDefault();
           _this2.taxonomy.topicClicked(topic);
+          topic.checkbox.dispatchEvent(new Event('click'));
         }
       }, false);
     }
@@ -837,24 +852,10 @@ var MillerColumnsSelectedElement = function (_CustomElement3) {
       }
     }
   }, {
-    key: 'selectedTopicNames',
+    key: 'update',
 
-
-    /** Used as an API into the underlying data represented */
-    value: function selectedTopicNames() {
-      if (!this.taxonomy) {
-        return [];
-      }
-
-      return this.taxonomy.selectedTopics.map(function (topic) {
-        return topic.topicNames;
-      });
-    }
 
     /** Update the UI to show the selected topics */
-
-  }, {
-    key: 'update',
     value: function update(taxonomy) {
       this.taxonomy = taxonomy;
       var selectedTopics = taxonomy.selectedTopics;
@@ -952,6 +953,7 @@ var MillerColumnsSelectedElement = function (_CustomElement3) {
       button.textContent = 'Remove topic';
       button.setAttribute('type', 'button');
       button.addEventListener('click', function () {
+        triggerEvent(button, 'remove-topic', topic);
         if (_this6.taxonomy) {
           _this6.taxonomy.removeTopic(topic);
         }

--- a/dist/index.umd.js
+++ b/dist/index.umd.js
@@ -77,6 +77,20 @@
     return Array.prototype.slice.call(nodes);
   }
 
+  function triggerEvent(element, eventName, detail) {
+    var params = { bubbles: true, cancelable: true, detail: detail || null };
+    var event = void 0;
+
+    if (typeof window.CustomEvent === 'function') {
+      event = new window.CustomEvent(eventName, params);
+    } else {
+      event = document.createEvent('CustomEvent');
+      event.initCustomEvent(eventName, params.bubbles, params.cancelable, params.detail);
+    }
+
+    element.dispatchEvent(event);
+  }
+
   /**
    * This models the taxonomy shown in the miller columns and the current state
    * of it.
@@ -122,7 +136,6 @@
           topic.select();
           this.active = topic;
         }
-
         this.millerColumns.update();
       }
     }, {
@@ -576,12 +589,14 @@
 
         trigger.tabIndex = 0;
         trigger.addEventListener('click', function () {
-          return _this2.taxonomy.topicClicked(topic);
+          _this2.taxonomy.topicClicked(topic);
+          topic.checkbox.dispatchEvent(new Event('click'));
         }, false);
         trigger.addEventListener('keydown', function (event) {
           if ([' ', 'Enter'].indexOf(event.key) !== -1) {
             event.preventDefault();
             _this2.taxonomy.topicClicked(topic);
+            topic.checkbox.dispatchEvent(new Event('click'));
           }
         }, false);
       }
@@ -821,17 +836,6 @@
         }
       }
     }, {
-      key: 'selectedTopicNames',
-      value: function selectedTopicNames() {
-        if (!this.taxonomy) {
-          return [];
-        }
-
-        return this.taxonomy.selectedTopics.map(function (topic) {
-          return topic.topicNames;
-        });
-      }
-    }, {
       key: 'update',
       value: function update(taxonomy) {
         this.taxonomy = taxonomy;
@@ -930,6 +934,7 @@
         button.textContent = 'Remove topic';
         button.setAttribute('type', 'button');
         button.addEventListener('click', function () {
+          triggerEvent(button, 'remove-topic', topic);
           if (_this6.taxonomy) {
             _this6.taxonomy.removeTopic(topic);
           }

--- a/dist/main.css
+++ b/dist/main.css
@@ -1354,10 +1354,9 @@
 
 .js-enabled .miller-columns {
   display: none; }
-
-.js-enabled .govuk-checkboxes__input,
-.js-enabled .govuk-checkboxes__label {
-  pointer-events: none; }
+  .js-enabled .miller-columns .govuk-checkboxes__input,
+  .js-enabled .miller-columns .govuk-checkboxes__label {
+    pointer-events: none; }
 
 .miller-columns {
   display: block;

--- a/dist/main.css
+++ b/dist/main.css
@@ -12,7 +12,7 @@
 
 .govuk-form-group--error {
   padding-left: 15px;
-  border-left: 5px solid #b10e1e; }
+  border-left: 5px solid #d4351c; }
   .govuk-form-group--error .govuk-form-group {
     padding: 0;
     border: 0; }
@@ -136,9 +136,11 @@
       padding-top: 40px;
       padding-bottom: 40px; } }
 
+.govuk-main-wrapper--auto-spacing:first-child,
 .govuk-main-wrapper--l {
   padding-top: 30px; }
   @media (min-width: 40.0625em) {
+    .govuk-main-wrapper--auto-spacing:first-child,
     .govuk-main-wrapper--l {
       padding-top: 50px; } }
 
@@ -164,39 +166,21 @@
           margin: 0 auto; } } }
 
 .govuk-link {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale; }
 
 /*! Copyright (c) 2011 by Margaret Calvert & Henrik Kubel. All rights reserved. The font has been customised for exclusive use on gov.uk. This cut is not commercially available. */
 @font-face {
-  font-family: "nta";
-  src: url("/assets/fonts/light-2c037cf7e1-v1.eot");
-  src: url("/assets/fonts/light-2c037cf7e1-v1.eot?#iefix") format("embedded-opentype"), url("/assets/fonts/light-f38ad40456-v1.woff2") format("woff2"), url("/assets/fonts/light-458f8ea81c-v1.woff") format("woff");
+  font-family: "GDS Transport";
+  src: url("/assets/fonts/light-94a07e06a1-v2.woff2") format("woff2"), url("/assets/fonts/light-f591b13f7d-v2.woff") format("woff");
   font-weight: normal;
   font-style: normal;
   font-display: fallback; }
 
 @font-face {
-  font-family: "nta";
-  src: url("/assets/fonts/bold-fb2676462a-v1.eot");
-  src: url("/assets/fonts/bold-fb2676462a-v1.eot?#iefix") format("embedded-opentype"), url("/assets/fonts/bold-a2452cb66f-v1.woff2") format("woff2"), url("/assets/fonts/bold-f38c792ac2-v1.woff") format("woff");
-  font-weight: bold;
-  font-style: normal;
-  font-display: fallback; }
-
-@font-face {
-  font-family: "ntatabularnumbers";
-  src: url("/assets/fonts/light-tabular-498ea8ffe2-v1.eot");
-  src: url("/assets/fonts/light-tabular-498ea8ffe2-v1.eot?#iefix") format("embedded-opentype"), url("/assets/fonts/light-tabular-851b10ccdd-v1.woff2") format("woff2"), url("/assets/fonts/light-tabular-62cc6f0a28-v1.woff") format("woff");
-  font-weight: normal;
-  font-style: normal;
-  font-display: fallback; }
-
-@font-face {
-  font-family: "ntatabularnumbers";
-  src: url("/assets/fonts/bold-tabular-357fdfbcc3-v1.eot");
-  src: url("/assets/fonts/bold-tabular-357fdfbcc3-v1.eot?#iefix") format("embedded-opentype"), url("/assets/fonts/bold-tabular-b89238d840-v1.woff2") format("woff2"), url("/assets/fonts/bold-tabular-784c21afb8-v1.woff") format("woff");
+  font-family: "GDS Transport";
+  src: url("/assets/fonts/bold-b542beb274-v2.woff2") format("woff2"), url("/assets/fonts/bold-affa96571d-v2.woff") format("woff");
   font-weight: bold;
   font-style: normal;
   font-display: fallback; }
@@ -204,17 +188,19 @@
     .govuk-link {
       font-family: sans-serif; } }
   .govuk-link:focus {
-    outline: 3px solid #ffbf47;
-    outline-offset: 0;
-    background-color: #ffbf47; }
+    outline: 3px solid transparent;
+    color: #0b0c0c;
+    background-color: #ffdd00;
+    box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+    text-decoration: none; }
   .govuk-link:link {
-    color: #005ea5; }
+    color: #1d70b8; }
   .govuk-link:visited {
     color: #4c2c92; }
   .govuk-link:hover {
-    color: #2b8cc4; }
+    color: #003078; }
   .govuk-link:active {
-    color: #2b8cc4; }
+    color: #0b0c0c; }
   .govuk-link:focus {
     color: #0b0c0c; }
   @media print {
@@ -236,22 +222,22 @@
       color: #000000; } }
 
 .govuk-link--no-visited-state:link {
-  color: #005ea5; }
+  color: #1d70b8; }
 
 .govuk-link--no-visited-state:visited {
-  color: #005ea5; }
+  color: #1d70b8; }
 
 .govuk-link--no-visited-state:hover {
-  color: #2b8cc4; }
+  color: #003078; }
 
 .govuk-link--no-visited-state:active {
-  color: #2b8cc4; }
+  color: #0b0c0c; }
 
 .govuk-link--no-visited-state:focus {
   color: #0b0c0c; }
 
 .govuk-list {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -304,7 +290,7 @@
       margin-bottom: 5px; } }
 
 .govuk-template {
-  background-color: #dee0e2;
+  background-color: #f3f2f1;
   -webkit-text-size-adjust: 100%;
   -moz-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
@@ -319,7 +305,7 @@
 
 .govuk-heading-xl {
   color: #0b0c0c;
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -350,7 +336,7 @@
 
 .govuk-heading-l {
   color: #0b0c0c;
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -381,7 +367,7 @@
 
 .govuk-heading-m {
   color: #0b0c0c;
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -412,7 +398,7 @@
 
 .govuk-heading-s {
   color: #0b0c0c;
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -442,7 +428,7 @@
       margin-bottom: 20px; } }
 
 .govuk-caption-xl {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -466,7 +452,7 @@
       line-height: 1.15; } }
 
 .govuk-caption-l {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -493,7 +479,7 @@
       margin-bottom: 0; } }
 
 .govuk-caption-m {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -517,7 +503,7 @@
 
 .govuk-body-l, .govuk-body-lead {
   color: #0b0c0c;
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -547,7 +533,7 @@
 
 .govuk-body-m, .govuk-body {
   color: #0b0c0c;
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -577,7 +563,7 @@
 
 .govuk-body-s {
   color: #0b0c0c;
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -607,7 +593,7 @@
 
 .govuk-body-xs {
   color: #0b0c0c;
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -704,10 +690,10 @@
       margin-bottom: 20px; } }
 
 .govuk-section-break--visible {
-  border-bottom: 1px solid #bfc1c3; }
+  border-bottom: 1px solid #b1b4b6; }
 
 .govuk-error-message {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -717,7 +703,7 @@
   display: block;
   margin-bottom: 15px;
   clear: both;
-  color: #b10e1e; }
+  color: #d4351c; }
   @media print {
     .govuk-error-message {
       font-family: sans-serif; } }
@@ -747,7 +733,7 @@
     display: table-cell; } }
 
 .govuk-fieldset__legend {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -760,7 +746,6 @@
   max-width: 100%;
   margin-bottom: 10px;
   padding: 0;
-  overflow: hidden;
   white-space: normal; }
   @media print {
     .govuk-fieldset__legend {
@@ -779,7 +764,7 @@
       color: #000000; } }
 
 .govuk-fieldset__legend--xl {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -801,7 +786,7 @@
       line-height: 1.15; } }
 
 .govuk-fieldset__legend--l {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -823,7 +808,7 @@
       line-height: 1.05; } }
 
 .govuk-fieldset__legend--m {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -845,7 +830,7 @@
       line-height: 1.15; } }
 
 .govuk-fieldset__legend--s {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -871,7 +856,7 @@
   font-weight: inherit; }
 
 .govuk-hint {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -905,7 +890,7 @@
   margin-top: -5px; }
 
 .govuk-label {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -932,7 +917,7 @@
       color: #000000; } }
 
 .govuk-label--xl {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -954,7 +939,7 @@
       line-height: 1.15; } }
 
 .govuk-label--l {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -976,7 +961,7 @@
       line-height: 1.05; } }
 
 .govuk-label--m {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -998,7 +983,7 @@
       line-height: 1.15; } }
 
 .govuk-label--s {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -1022,7 +1007,7 @@
   margin: 0; }
 
 .govuk-checkboxes__item {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -1104,9 +1089,8 @@
   padding-left: 15px; }
 
 .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
-  outline: 3px solid transparent;
-  outline-offset: 3px;
-  box-shadow: 0 0 0 3px #ffbf47; }
+  border-width: 4px;
+  box-shadow: 0 0 0 3px #ffdd00; }
 
 .govuk-checkboxes__input:checked + .govuk-checkboxes__label::after {
   opacity: 1; }
@@ -1122,7 +1106,7 @@
   margin-bottom: 15px;
   margin-left: 18px;
   padding-left: 33px;
-  border-left: 4px solid #bfc1c3; }
+  border-left: 4px solid #b1b4b6; }
   @media (min-width: 40.0625em) {
     .govuk-checkboxes__conditional {
       margin-bottom: 20px; } }
@@ -1174,19 +1158,19 @@
   clear: both; }
 
 .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
-  box-shadow: 0 0 0 10px #dee0e2; }
+  box-shadow: 0 0 0 10px #b1b4b6; }
 
 .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
-  box-shadow: 0 0 0 3px #ffbf47, 0 0 0 10px #dee0e2; }
+  box-shadow: 0 0 0 3px #ffdd00, 0 0 0 10px #b1b4b6; }
 
 @media (hover: none), (pointer: coarse) {
   .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
     box-shadow: initial; }
   .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
-    box-shadow: 0 0 0 3px #ffbf47; } }
+    box-shadow: 0 0 0 3px #ffdd00; } }
 
 .govuk-breadcrumbs {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -1232,8 +1216,8 @@
     content: "";
     display: block;
     position: absolute;
-    top: -1px;
-    bottom: 1px;
+    top: 0;
+    bottom: 0;
     left: -3.31px;
     width: 7px;
     height: 7px;
@@ -1252,16 +1236,18 @@
       display: none; }
 
 .govuk-breadcrumbs__link {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale; }
   @media print {
     .govuk-breadcrumbs__link {
       font-family: sans-serif; } }
   .govuk-breadcrumbs__link:focus {
-    outline: 3px solid #ffbf47;
-    outline-offset: 0;
-    background-color: #ffbf47; }
+    outline: 3px solid transparent;
+    color: #0b0c0c;
+    background-color: #ffdd00;
+    box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+    text-decoration: none; }
   .govuk-breadcrumbs__link:link, .govuk-breadcrumbs__link:visited, .govuk-breadcrumbs__link:hover, .govuk-breadcrumbs__link:active, .govuk-breadcrumbs__link:focus {
     color: #0b0c0c; }
     @media print {
@@ -1282,7 +1268,7 @@
     margin-bottom: 0; }
 
 .miller-columns-selected__list {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -1313,12 +1299,12 @@
   position: relative;
   margin-bottom: 0;
   padding: 10px 0;
-  border-top: 1px solid #bfc1c3; }
+  border-top: 1px solid #b1b4b6; }
   .miller-columns-selected__list-item:last-child {
-    border-bottom: 1px solid #bfc1c3; }
+    border-bottom: 1px solid #b1b4b6; }
 
 .miller-columns-selected__remove-topic {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -1331,14 +1317,10 @@
   margin: 0;
   padding: 0;
   border: 0;
-  color: #005ea5;
+  color: #1d70b8;
   background: transparent;
   text-decoration: underline;
   cursor: pointer; }
-  .miller-columns-selected__remove-topic:focus {
-    outline: 3px solid #ffbf47;
-    outline-offset: 0;
-    background-color: #ffbf47; }
   @media print {
     .miller-columns-selected__remove-topic {
       font-family: sans-serif; } }
@@ -1351,6 +1333,12 @@
     .miller-columns-selected__remove-topic {
       font-size: 14pt;
       line-height: 1.2; } }
+  .miller-columns-selected__remove-topic:focus {
+    outline: 3px solid transparent;
+    color: #0b0c0c;
+    background-color: #ffdd00;
+    box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+    text-decoration: none; }
 
 .js-enabled .miller-columns {
   display: none; }
@@ -1376,7 +1364,7 @@
   height: 100%;
   margin: 0;
   padding: 0;
-  border-right: 1px solid #bfc1c3;
+  border-right: 1px solid #b1b4b6;
   vertical-align: top;
   white-space: normal;
   transition-duration: 400ms;
@@ -1410,7 +1398,7 @@
   list-style: none;
   color: #0b0c0c;
   cursor: pointer;
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -1429,16 +1417,19 @@
     .miller-columns__item {
       font-size: 14pt;
       line-height: 1.2; } }
-  .miller-columns__item:focus {
-    outline: 3px solid #ffbf47;
-    outline-offset: 0; }
-  .miller-columns__item:focus, .miller-columns__item:hover {
+  .miller-columns__item:hover {
     color: #0b0c0c;
-    background-color: #dee0e2; }
+    background-color: #b1b4b6; }
+  .miller-columns__item:focus {
+    outline: 3px solid transparent;
+    color: #0b0c0c;
+    background-color: #ffdd00;
+    box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+    text-decoration: none; }
   .miller-columns__item .govuk-checkboxes__item {
     float: none; }
   .miller-columns__item .govuk-checkboxes__label {
-    font-family: "nta", Arial, sans-serif;
+    font-family: "GDS Transport", Arial, sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     font-weight: 400;
@@ -1472,24 +1463,39 @@
   font-size: 24px; }
 
 .miller-columns__item--selected,
-.miller-columns__item--selected:focus,
 .miller-columns__item--selected:hover {
   color: #ffffff;
   background-color: #6f777b; }
   .miller-columns__item--selected .govuk-checkboxes__label,
-  .miller-columns__item--selected:focus .govuk-checkboxes__label,
   .miller-columns__item--selected:hover .govuk-checkboxes__label {
     color: #ffffff; }
 
+.miller-columns__item--selected:focus {
+  outline: 3px solid transparent;
+  color: #0b0c0c;
+  background-color: #ffdd00;
+  box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+  text-decoration: none; }
+  .miller-columns__item--selected:focus .govuk-checkboxes__label {
+    color: #0b0c0c; }
+
 .miller-columns__item--active,
-.miller-columns__item--active:focus,
 .miller-columns__item--active:hover {
   color: #ffffff;
-  background-color: #005ea5; }
+  background-color: #1d70b8;
+  box-shadow: none; }
   .miller-columns__item--active .govuk-checkboxes__label,
-  .miller-columns__item--active:focus .govuk-checkboxes__label,
   .miller-columns__item--active:hover .govuk-checkboxes__label {
     color: #ffffff; }
+
+.miller-columns__item--active:focus {
+  outline: 3px solid transparent;
+  color: #0b0c0c;
+  background-color: #ffdd00;
+  box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+  text-decoration: none; }
+  .miller-columns__item--active:focus .govuk-checkboxes__label {
+    color: #0b0c0c; }
 
 .miller-columns .govuk-list .govuk-list {
   margin-left: 30px; }

--- a/dist/miller-columns.css
+++ b/dist/miller-columns.css
@@ -1,5 +1,5 @@
 .govuk-error-message {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -9,37 +9,19 @@
   display: block;
   margin-bottom: 15px;
   clear: both;
-  color: #b10e1e; }
+  color: #d4351c; }
 
 /*! Copyright (c) 2011 by Margaret Calvert & Henrik Kubel. All rights reserved. The font has been customised for exclusive use on gov.uk. This cut is not commercially available. */
 @font-face {
-  font-family: "nta";
-  src: url("/assets/fonts/light-2c037cf7e1-v1.eot");
-  src: url("/assets/fonts/light-2c037cf7e1-v1.eot?#iefix") format("embedded-opentype"), url("/assets/fonts/light-f38ad40456-v1.woff2") format("woff2"), url("/assets/fonts/light-458f8ea81c-v1.woff") format("woff");
+  font-family: "GDS Transport";
+  src: url("/assets/fonts/light-94a07e06a1-v2.woff2") format("woff2"), url("/assets/fonts/light-f591b13f7d-v2.woff") format("woff");
   font-weight: normal;
   font-style: normal;
   font-display: fallback; }
 
 @font-face {
-  font-family: "nta";
-  src: url("/assets/fonts/bold-fb2676462a-v1.eot");
-  src: url("/assets/fonts/bold-fb2676462a-v1.eot?#iefix") format("embedded-opentype"), url("/assets/fonts/bold-a2452cb66f-v1.woff2") format("woff2"), url("/assets/fonts/bold-f38c792ac2-v1.woff") format("woff");
-  font-weight: bold;
-  font-style: normal;
-  font-display: fallback; }
-
-@font-face {
-  font-family: "ntatabularnumbers";
-  src: url("/assets/fonts/light-tabular-498ea8ffe2-v1.eot");
-  src: url("/assets/fonts/light-tabular-498ea8ffe2-v1.eot?#iefix") format("embedded-opentype"), url("/assets/fonts/light-tabular-851b10ccdd-v1.woff2") format("woff2"), url("/assets/fonts/light-tabular-62cc6f0a28-v1.woff") format("woff");
-  font-weight: normal;
-  font-style: normal;
-  font-display: fallback; }
-
-@font-face {
-  font-family: "ntatabularnumbers";
-  src: url("/assets/fonts/bold-tabular-357fdfbcc3-v1.eot");
-  src: url("/assets/fonts/bold-tabular-357fdfbcc3-v1.eot?#iefix") format("embedded-opentype"), url("/assets/fonts/bold-tabular-b89238d840-v1.woff2") format("woff2"), url("/assets/fonts/bold-tabular-784c21afb8-v1.woff") format("woff");
+  font-family: "GDS Transport";
+  src: url("/assets/fonts/bold-b542beb274-v2.woff2") format("woff2"), url("/assets/fonts/bold-affa96571d-v2.woff") format("woff");
   font-weight: bold;
   font-style: normal;
   font-display: fallback; }
@@ -72,7 +54,7 @@
     display: table-cell; } }
 
 .govuk-fieldset__legend {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -85,7 +67,6 @@
   max-width: 100%;
   margin-bottom: 10px;
   padding: 0;
-  overflow: hidden;
   white-space: normal; }
   @media print {
     .govuk-fieldset__legend {
@@ -104,7 +85,7 @@
       color: #000000; } }
 
 .govuk-fieldset__legend--xl {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -126,7 +107,7 @@
       line-height: 1.15; } }
 
 .govuk-fieldset__legend--l {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -148,7 +129,7 @@
       line-height: 1.05; } }
 
 .govuk-fieldset__legend--m {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -170,7 +151,7 @@
       line-height: 1.15; } }
 
 .govuk-fieldset__legend--s {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -196,7 +177,7 @@
   font-weight: inherit; }
 
 .govuk-hint {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -230,7 +211,7 @@
   margin-top: -5px; }
 
 .govuk-label {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -257,7 +238,7 @@
       color: #000000; } }
 
 .govuk-label--xl {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -279,7 +260,7 @@
       line-height: 1.15; } }
 
 .govuk-label--l {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -301,7 +282,7 @@
       line-height: 1.05; } }
 
 .govuk-label--m {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -323,7 +304,7 @@
       line-height: 1.15; } }
 
 .govuk-label--s {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
@@ -347,7 +328,7 @@
   margin: 0; }
 
 .govuk-checkboxes__item {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -429,9 +410,8 @@
   padding-left: 15px; }
 
 .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
-  outline: 3px solid transparent;
-  outline-offset: 3px;
-  box-shadow: 0 0 0 3px #ffbf47; }
+  border-width: 4px;
+  box-shadow: 0 0 0 3px #ffdd00; }
 
 .govuk-checkboxes__input:checked + .govuk-checkboxes__label::after {
   opacity: 1; }
@@ -447,7 +427,7 @@
   margin-bottom: 15px;
   margin-left: 18px;
   padding-left: 33px;
-  border-left: 4px solid #bfc1c3; }
+  border-left: 4px solid #b1b4b6; }
   @media (min-width: 40.0625em) {
     .govuk-checkboxes__conditional {
       margin-bottom: 20px; } }
@@ -499,19 +479,19 @@
   clear: both; }
 
 .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
-  box-shadow: 0 0 0 10px #dee0e2; }
+  box-shadow: 0 0 0 10px #b1b4b6; }
 
 .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
-  box-shadow: 0 0 0 3px #ffbf47, 0 0 0 10px #dee0e2; }
+  box-shadow: 0 0 0 3px #ffdd00, 0 0 0 10px #b1b4b6; }
 
 @media (hover: none), (pointer: coarse) {
   .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
     box-shadow: initial; }
   .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
-    box-shadow: 0 0 0 3px #ffbf47; } }
+    box-shadow: 0 0 0 3px #ffdd00; } }
 
 .govuk-breadcrumbs {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -557,8 +537,8 @@
     content: "";
     display: block;
     position: absolute;
-    top: -1px;
-    bottom: 1px;
+    top: 0;
+    bottom: 0;
     left: -3.31px;
     width: 7px;
     height: 7px;
@@ -577,16 +557,18 @@
       display: none; }
 
 .govuk-breadcrumbs__link {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale; }
   @media print {
     .govuk-breadcrumbs__link {
       font-family: sans-serif; } }
   .govuk-breadcrumbs__link:focus {
-    outline: 3px solid #ffbf47;
-    outline-offset: 0;
-    background-color: #ffbf47; }
+    outline: 3px solid transparent;
+    color: #0b0c0c;
+    background-color: #ffdd00;
+    box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+    text-decoration: none; }
   .govuk-breadcrumbs__link:link, .govuk-breadcrumbs__link:visited, .govuk-breadcrumbs__link:hover, .govuk-breadcrumbs__link:active, .govuk-breadcrumbs__link:focus {
     color: #0b0c0c; }
     @media print {
@@ -607,7 +589,7 @@
     margin-bottom: 0; }
 
 .miller-columns-selected__list {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -638,12 +620,12 @@
   position: relative;
   margin-bottom: 0;
   padding: 10px 0;
-  border-top: 1px solid #bfc1c3; }
+  border-top: 1px solid #b1b4b6; }
   .miller-columns-selected__list-item:last-child {
-    border-bottom: 1px solid #bfc1c3; }
+    border-bottom: 1px solid #b1b4b6; }
 
 .miller-columns-selected__remove-topic {
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -656,14 +638,10 @@
   margin: 0;
   padding: 0;
   border: 0;
-  color: #005ea5;
+  color: #1d70b8;
   background: transparent;
   text-decoration: underline;
   cursor: pointer; }
-  .miller-columns-selected__remove-topic:focus {
-    outline: 3px solid #ffbf47;
-    outline-offset: 0;
-    background-color: #ffbf47; }
   @media print {
     .miller-columns-selected__remove-topic {
       font-family: sans-serif; } }
@@ -676,6 +654,12 @@
     .miller-columns-selected__remove-topic {
       font-size: 14pt;
       line-height: 1.2; } }
+  .miller-columns-selected__remove-topic:focus {
+    outline: 3px solid transparent;
+    color: #0b0c0c;
+    background-color: #ffdd00;
+    box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+    text-decoration: none; }
 
 .js-enabled .miller-columns {
   display: none; }
@@ -701,7 +685,7 @@
   height: 100%;
   margin: 0;
   padding: 0;
-  border-right: 1px solid #bfc1c3;
+  border-right: 1px solid #b1b4b6;
   vertical-align: top;
   white-space: normal;
   transition-duration: 400ms;
@@ -735,7 +719,7 @@
   list-style: none;
   color: #0b0c0c;
   cursor: pointer;
-  font-family: "nta", Arial, sans-serif;
+  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
@@ -754,16 +738,19 @@
     .miller-columns__item {
       font-size: 14pt;
       line-height: 1.2; } }
-  .miller-columns__item:focus {
-    outline: 3px solid #ffbf47;
-    outline-offset: 0; }
-  .miller-columns__item:focus, .miller-columns__item:hover {
+  .miller-columns__item:hover {
     color: #0b0c0c;
-    background-color: #dee0e2; }
+    background-color: #b1b4b6; }
+  .miller-columns__item:focus {
+    outline: 3px solid transparent;
+    color: #0b0c0c;
+    background-color: #ffdd00;
+    box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+    text-decoration: none; }
   .miller-columns__item .govuk-checkboxes__item {
     float: none; }
   .miller-columns__item .govuk-checkboxes__label {
-    font-family: "nta", Arial, sans-serif;
+    font-family: "GDS Transport", Arial, sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     font-weight: 400;
@@ -797,24 +784,39 @@
   font-size: 24px; }
 
 .miller-columns__item--selected,
-.miller-columns__item--selected:focus,
 .miller-columns__item--selected:hover {
   color: #ffffff;
   background-color: #6f777b; }
   .miller-columns__item--selected .govuk-checkboxes__label,
-  .miller-columns__item--selected:focus .govuk-checkboxes__label,
   .miller-columns__item--selected:hover .govuk-checkboxes__label {
     color: #ffffff; }
 
+.miller-columns__item--selected:focus {
+  outline: 3px solid transparent;
+  color: #0b0c0c;
+  background-color: #ffdd00;
+  box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+  text-decoration: none; }
+  .miller-columns__item--selected:focus .govuk-checkboxes__label {
+    color: #0b0c0c; }
+
 .miller-columns__item--active,
-.miller-columns__item--active:focus,
 .miller-columns__item--active:hover {
   color: #ffffff;
-  background-color: #005ea5; }
+  background-color: #1d70b8;
+  box-shadow: none; }
   .miller-columns__item--active .govuk-checkboxes__label,
-  .miller-columns__item--active:focus .govuk-checkboxes__label,
   .miller-columns__item--active:hover .govuk-checkboxes__label {
     color: #ffffff; }
+
+.miller-columns__item--active:focus {
+  outline: 3px solid transparent;
+  color: #0b0c0c;
+  background-color: #ffdd00;
+  box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+  text-decoration: none; }
+  .miller-columns__item--active:focus .govuk-checkboxes__label {
+    color: #0b0c0c; }
 
 .miller-columns .govuk-list .govuk-list {
   margin-left: 30px; }

--- a/dist/miller-columns.css
+++ b/dist/miller-columns.css
@@ -679,10 +679,9 @@
 
 .js-enabled .miller-columns {
   display: none; }
-
-.js-enabled .govuk-checkboxes__input,
-.js-enabled .govuk-checkboxes__label {
-  pointer-events: none; }
+  .js-enabled .miller-columns .govuk-checkboxes__input,
+  .js-enabled .miller-columns .govuk-checkboxes__label {
+    pointer-events: none; }
 
 .miller-columns {
   display: block;

--- a/main.scss
+++ b/main.scss
@@ -1,6 +1,6 @@
 // Core styles used for the example pages
-@import "node_modules/govuk-frontend/objects/all";
-@import "node_modules/govuk-frontend/core/all";
+@import "node_modules/govuk-frontend/govuk/objects/all";
+@import "node_modules/govuk-frontend/govuk/core/all";
 
 // Component specific styles
 @import "miller-columns";

--- a/miller-columns-selected.scss
+++ b/miller-columns-selected.scss
@@ -1,7 +1,7 @@
-@import "node_modules/govuk-frontend/settings/all";
-@import "node_modules/govuk-frontend/tools/all";
-@import "node_modules/govuk-frontend/helpers/all";
-@import "node_modules/govuk-frontend/components/breadcrumbs/breadcrumbs";
+@import "node_modules/govuk-frontend/govuk/settings/all";
+@import "node_modules/govuk-frontend/govuk/tools/all";
+@import "node_modules/govuk-frontend/govuk/helpers/all";
+@import "node_modules/govuk-frontend/govuk/components/breadcrumbs/breadcrumbs";
 
 .miller-columns-selected {
   @include govuk-responsive-margin(6, "bottom");
@@ -38,7 +38,6 @@
 }
 
 .miller-columns-selected__remove-topic {
-  @include govuk-focusable-fill;
   @include govuk-font($size: 16);
   position: absolute;
   top: govuk-spacing(2);
@@ -50,4 +49,8 @@
   background: transparent;
   text-decoration: underline;
   cursor: pointer;
+
+  &:focus {
+    @include govuk-focused-text;
+  }
 }

--- a/miller-columns.scss
+++ b/miller-columns.scss
@@ -1,12 +1,12 @@
-@import "node_modules/govuk-frontend/settings/all";
-@import "node_modules/govuk-frontend/tools/all";
-@import "node_modules/govuk-frontend/helpers/all";
-@import "node_modules/govuk-frontend/components/checkboxes/checkboxes";
+@import "node_modules/govuk-frontend/govuk/settings/all";
+@import "node_modules/govuk-frontend/govuk/tools/all";
+@import "node_modules/govuk-frontend/govuk/helpers/all";
+@import "node_modules/govuk-frontend/govuk/components/checkboxes/checkboxes";
 @import "miller-columns-selected";
 
 $mc-transition-time: 400ms;
 $mc-selected-item-colour: govuk-colour("white");
-$mc-selected-item-background: govuk-colour("grey-1");
+$mc-selected-item-background: govuk-colour("dark-grey");
 $mc-active-item-colour: govuk-colour("white");
 $mc-active-item-background: govuk-colour("blue");
 
@@ -86,12 +86,14 @@ $mc-active-item-background: govuk-colour("blue");
   color: $govuk-text-colour;
   cursor: pointer;
   @include govuk-font($size: 16);
-  @include govuk-focusable;
 
-  &:focus,
   &:hover {
     color: govuk-colour("black");
     background-color: $govuk-hover-colour;
+  }
+
+  &:focus {
+    @include govuk-focused-text;
   }
 
   .govuk-checkboxes__item {
@@ -122,7 +124,6 @@ $mc-active-item-background: govuk-colour("blue");
 }
 
 .miller-columns__item--selected,
-.miller-columns__item--selected:focus,
 .miller-columns__item--selected:hover {
   color: $mc-selected-item-colour;
   background-color: $mc-selected-item-background;
@@ -132,14 +133,30 @@ $mc-active-item-background: govuk-colour("blue");
   }
 }
 
+.miller-columns__item--selected:focus {
+  @include govuk-focused-text;
+
+  .govuk-checkboxes__label {
+    color: $govuk-text-colour;
+  }
+}
+
 .miller-columns__item--active,
-.miller-columns__item--active:focus,
 .miller-columns__item--active:hover {
   color: $mc-active-item-colour;
   background-color: $mc-active-item-background;
+  box-shadow: none;
 
   .govuk-checkboxes__label {
     color: $mc-active-item-colour;
+  }
+}
+
+.miller-columns__item--active:focus {
+  @include govuk-focused-text;
+
+  .govuk-checkboxes__label {
+    color: $govuk-text-colour;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3979,7 +3979,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
@@ -4005,9 +4005,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.13.0.tgz",
-      "integrity": "sha512-6XDtTt5plSrPQvPgLFN4LCtb9ULuqoXCgkHy5c7XE/70/sVm47RPbLR11tYGPcmV8cOApBhW0wL8y8ryspHfpw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.2.0.tgz",
+      "integrity": "sha512-OtJozAGMEKFu195fNVVrQHUX7+znCkA4cXDKs4lgFlRQOTzN1ogT9010GBARuoTwbeL0VqQ8nerZYjVxH/wafA==",
       "dev": true
     },
     "graceful-fs": {
@@ -5672,7 +5672,7 @@
       "dependencies": {
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -5685,7 +5685,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -5974,7 +5974,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -7566,7 +7566,7 @@
         },
         "acorn-jsx": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
           "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
           "dev": true,
           "requires": {
@@ -7575,7 +7575,7 @@
           "dependencies": {
             "acorn": {
               "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
               "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
               "dev": true
             }
@@ -7624,7 +7624,7 @@
         },
         "eslint": {
           "version": "2.13.1",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+          "resolved": "http://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
           "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
           "dev": true,
           "requires": {
@@ -7665,7 +7665,7 @@
         },
         "espree": {
           "version": "3.5.4",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+          "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
           "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
           "dev": true,
           "requires": {
@@ -7713,7 +7713,7 @@
         },
         "inquirer": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true,
           "requires": {
@@ -7743,13 +7743,13 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
         "progress": {
           "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "resolved": "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
           "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
           "dev": true
         },
@@ -7774,7 +7774,7 @@
         },
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         },
@@ -7797,7 +7797,7 @@
         },
         "table": {
           "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+          "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
           "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
           "dev": true,
           "requires": {
@@ -7911,9 +7911,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -8777,38 +8777,15 @@
       }
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unique-string": {
@@ -9230,7 +9207,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint": "^5.16.0",
     "eslint-plugin-github": "1.0.0",
     "flow-bin": "^0.75.0",
-    "govuk-frontend": "^2.13.0",
+    "govuk-frontend": "^3.2.0",
     "karma": "^4.1.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",


### PR DESCRIPTION
This PR updates miller-columns-element to govuk-frontend 3.2 (latest version) which includes a breaking change.

Below you have all the states an item can be in (from left to right on the first row): `selected`, `active`, `focused`, `hovered`

This update is required to [update Content Publisher to the latest version of govuk_publishing_components](https://github.com/alphagov/content-publisher/pull/1355) (which includes similar updates rolled out with govuk-frontend 3.2).

### Before
<img width="1018" alt="Screen Shot 2019-09-12 at 18 13 03" src="https://user-images.githubusercontent.com/788096/64805459-073a2e00-d589-11e9-86d8-0ff25f6671cb.png">

### After
<img width="1019" alt="Screen Shot 2019-09-12 at 18 11 54" src="https://user-images.githubusercontent.com/788096/64805469-0acdb500-d589-11e9-917a-8b1910ce6e95.png">
