### PR TITLE
Enhance mobile view

### DIFF
--- a/dist/index.umd.js
+++ b/dist/index.umd.js
@@ -500,9 +500,13 @@
 
       _this.classNames = {
         column: 'miller-columns__column',
+        columnHeading: 'miller-columns__column-heading',
+        backLink: 'govuk-back-link',
+        columnList: 'miller-columns__column-list',
         columnCollapse: 'miller-columns__column--collapse',
         columnMedium: 'miller-columns__column--medium',
         columnNarrow: 'miller-columns__column--narrow',
+        columnActive: 'miller-columns__column--active',
         item: 'miller-columns__item',
         itemParent: 'miller-columns__item--parent',
         itemActive: 'miller-columns__item--active',
@@ -528,16 +532,49 @@
     }, {
       key: 'renderTaxonomyColumn',
       value: function renderTaxonomyColumn(topics) {
+        var _this2 = this;
+
         var root = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
 
-        var ul = document.createElement('ul');
-        ul.className = this.classNames.column;
-        if (root) {
-          ul.dataset.root = 'true';
-        } else {
-          ul.classList.add(this.classNames.columnCollapse);
+        var div = document.createElement('div');
+
+        if (!root) {
+          // Append back link
+          var backLink = document.createElement('button');
+          backLink.className = this.classNames.backLink;
+          backLink.type = 'button';
+          backLink.innerHTML = 'Back';
+          backLink.addEventListener('click', function () {
+            if (topics[0].parent) {
+              _this2.showCurrentColumns(topics[0].parent.parent);
+            }
+          }, false);
+          div.appendChild(backLink);
+
+          // Append heading
+          var h3 = document.createElement('h3');
+          h3.className = this.classNames.columnHeading;
+          var parentTopicName = topics[0].parent ? topics[0].parent.topicName : null;
+          if (parentTopicName) {
+            h3.innerHTML = parentTopicName;
+          }
+          div.appendChild(h3);
         }
-        this.appendChild(ul);
+
+        // Append list
+        var ul = document.createElement('ul');
+        ul.className = this.classNames.columnList;
+        div.className = this.classNames.column;
+        if (root) {
+          div.dataset.root = 'true';
+        } else {
+          div.classList.add(this.classNames.columnCollapse);
+        }
+        div.appendChild(ul);
+
+        // Append column
+        this.appendChild(div);
+
         var _iteratorNormalCompletion7 = true;
         var _didIteratorError7 = false;
         var _iteratorError7 = undefined;
@@ -585,17 +622,17 @@
     }, {
       key: 'attachEvents',
       value: function attachEvents(trigger, topic) {
-        var _this2 = this;
+        var _this3 = this;
 
         trigger.tabIndex = 0;
         trigger.addEventListener('click', function () {
-          _this2.taxonomy.topicClicked(topic);
+          _this3.taxonomy.topicClicked(topic);
           topic.checkbox.dispatchEvent(new Event('click'));
         }, false);
         trigger.addEventListener('keydown', function (event) {
           if ([' ', 'Enter'].indexOf(event.key) !== -1) {
             event.preventDefault();
-            _this2.taxonomy.topicClicked(topic);
+            _this3.taxonomy.topicClicked(topic);
             topic.checkbox.dispatchEvent(new Event('click'));
           }
         }, false);
@@ -652,7 +689,7 @@
     }, {
       key: 'showSelectedTopics',
       value: function showSelectedTopics(selectedTopics) {
-        var _this3 = this;
+        var _this4 = this;
 
         var selectedItems = selectedTopics.reduce(function (memo, child) {
           var _iteratorNormalCompletion9 = true;
@@ -663,7 +700,7 @@
             for (var _iterator9 = child.withParents()[Symbol.iterator](), _step9; !(_iteratorNormalCompletion9 = (_step9 = _iterator9.next()).done); _iteratorNormalCompletion9 = true) {
               var topic = _step9.value;
 
-              var item = topic.checkbox.closest('.' + _this3.classNames.item);
+              var item = topic.checkbox.closest('.' + _this4.classNames.item);
               if (item instanceof HTMLElement) {
                 memo.push(item);
               }
@@ -691,7 +728,7 @@
     }, {
       key: 'showActiveTopic',
       value: function showActiveTopic(activeTopic) {
-        var _this4 = this;
+        var _this5 = this;
 
         var activeItems = void 0;
 
@@ -699,7 +736,7 @@
           activeItems = [];
         } else {
           activeItems = activeTopic.withParents().reduce(function (memo, topic) {
-            var item = topic.checkbox.closest('.' + _this4.classNames.item);
+            var item = topic.checkbox.closest('.' + _this5.classNames.item);
 
             if (item instanceof HTMLElement) {
               memo.push(item);
@@ -721,7 +758,8 @@
         var _classNames = this.classNames,
             collapseClass = _classNames.columnCollapse,
             narrowClass = _classNames.columnNarrow,
-            mediumClass = _classNames.columnMedium;
+            mediumClass = _classNames.columnMedium,
+            activeClass = _classNames.columnActive;
         var _iteratorNormalCompletion10 = true;
         var _didIteratorError10 = false;
         var _iteratorError10 = undefined;
@@ -735,6 +773,7 @@
               continue;
             }
 
+            item.classList.remove(activeClass);
             // we always want to show the root column
             if (item.dataset.root === 'true') {
               item.classList.remove(narrowClass, mediumClass);
@@ -742,6 +781,9 @@
                 item.classList.add(mediumClass);
               } else if (showNarrow) {
                 item.classList.add(narrowClass);
+              }
+              if (columnsToShow.length === 0) {
+                item.classList.add(activeClass);
               }
               continue;
             }
@@ -762,6 +804,11 @@
             } else {
               // show this column in all it's glory
               item.classList.remove(collapseClass, narrowClass, mediumClass);
+            }
+
+            // mark last column as active
+            if (item === columnsToShow[columnsToShow.length - 1]) {
+              item.classList.add(activeClass);
             }
           }
         } catch (err) {
@@ -927,7 +974,7 @@
     }, {
       key: 'removeTopicElement',
       value: function removeTopicElement(topic) {
-        var _this6 = this;
+        var _this7 = this;
 
         var button = document.createElement('button');
         button.className = 'miller-columns-selected__remove-topic';
@@ -935,8 +982,8 @@
         button.setAttribute('type', 'button');
         button.addEventListener('click', function () {
           triggerEvent(button, 'remove-topic', topic);
-          if (_this6.taxonomy) {
-            _this6.taxonomy.removeTopic(topic);
+          if (_this7.taxonomy) {
+            _this7.taxonomy.removeTopic(topic);
           }
         });
         return button;

--- a/dist/main.css
+++ b/dist/main.css
@@ -396,7 +396,7 @@
     .govuk-heading-m {
       margin-bottom: 20px; } }
 
-.govuk-heading-s {
+.govuk-heading-s, .miller-columns__column-heading {
   color: #0b0c0c;
   font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -409,22 +409,22 @@
   margin-top: 0;
   margin-bottom: 15px; }
   @media print {
-    .govuk-heading-s {
+    .govuk-heading-s, .miller-columns__column-heading {
       color: #000000; } }
   @media print {
-    .govuk-heading-s {
+    .govuk-heading-s, .miller-columns__column-heading {
       font-family: sans-serif; } }
   @media (min-width: 40.0625em) {
-    .govuk-heading-s {
+    .govuk-heading-s, .miller-columns__column-heading {
       font-size: 19px;
       font-size: 1.1875rem;
       line-height: 1.31579; } }
   @media print {
-    .govuk-heading-s {
+    .govuk-heading-s, .miller-columns__column-heading {
       font-size: 14pt;
       line-height: 1.15; } }
   @media (min-width: 40.0625em) {
-    .govuk-heading-s {
+    .govuk-heading-s, .miller-columns__column-heading {
       margin-bottom: 20px; } }
 
 .govuk-caption-xl {
@@ -642,8 +642,12 @@
 .govuk-list + .govuk-heading-m,
 .govuk-body-m + .govuk-heading-s,
 .govuk-body + .govuk-heading-s,
+.govuk-body-m + .miller-columns__column-heading,
+.govuk-body + .miller-columns__column-heading,
 .govuk-body-s + .govuk-heading-s,
-.govuk-list + .govuk-heading-s {
+.govuk-body-s + .miller-columns__column-heading,
+.govuk-list + .govuk-heading-s,
+.govuk-list + .miller-columns__column-heading {
   padding-top: 5px; }
   @media (min-width: 40.0625em) {
     .govuk-body-m + .govuk-heading-m, .govuk-body + .govuk-heading-m,
@@ -651,8 +655,12 @@
     .govuk-list + .govuk-heading-m,
     .govuk-body-m + .govuk-heading-s,
     .govuk-body + .govuk-heading-s,
+    .govuk-body-m + .miller-columns__column-heading,
+    .govuk-body + .miller-columns__column-heading,
     .govuk-body-s + .govuk-heading-s,
-    .govuk-list + .govuk-heading-s {
+    .govuk-body-s + .miller-columns__column-heading,
+    .govuk-list + .govuk-heading-s,
+    .govuk-list + .miller-columns__column-heading {
       padding-top: 10px; } }
 
 .govuk-section-break {
@@ -1169,6 +1177,62 @@
   .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
     box-shadow: 0 0 0 3px #ffdd00; } }
 
+.govuk-back-link {
+  font-size: 14px;
+  font-size: 0.875rem;
+  line-height: 1.14286;
+  font-family: "GDS Transport", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  display: inline-block;
+  position: relative;
+  margin-top: 15px;
+  margin-bottom: 15px;
+  padding-left: 14px;
+  border-bottom: 1px solid #0b0c0c;
+  text-decoration: none; }
+  @media (min-width: 40.0625em) {
+    .govuk-back-link {
+      font-size: 16px;
+      font-size: 1rem;
+      line-height: 1.25; } }
+  @media print {
+    .govuk-back-link {
+      font-size: 14pt;
+      line-height: 1.2; } }
+  @media print {
+    .govuk-back-link {
+      font-family: sans-serif; } }
+  .govuk-back-link:focus {
+    outline: 3px solid transparent;
+    color: #0b0c0c;
+    background-color: #ffdd00;
+    box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+    text-decoration: none; }
+  .govuk-back-link:link, .govuk-back-link:visited, .govuk-back-link:hover, .govuk-back-link:active, .govuk-back-link:focus {
+    color: #0b0c0c; }
+    @media print {
+      .govuk-back-link:link, .govuk-back-link:visited, .govuk-back-link:hover, .govuk-back-link:active, .govuk-back-link:focus {
+        color: #000000; } }
+  .govuk-back-link:focus {
+    border-bottom-color: transparent; }
+  .govuk-back-link:before {
+    display: block;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-color: transparent;
+    -webkit-clip-path: polygon(0% 50%, 100% 100%, 100% 0%);
+    clip-path: polygon(0% 50%, 100% 100%, 100% 0%);
+    border-width: 5px 6px 5px 0;
+    border-right-color: inherit;
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    margin: auto; }
+
 .govuk-breadcrumbs {
   font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -1359,16 +1423,20 @@
       margin-bottom: 30px; } }
 
 .miller-columns__column {
-  display: inline-block;
-  width: 33.3%;
+  display: none;
+  width: 100%;
   height: 100%;
-  margin: 0;
-  padding: 0;
-  border-right: 1px solid #b1b4b6;
   vertical-align: top;
   white-space: normal;
   transition-duration: 400ms;
   transition-property: width; }
+  .miller-columns__column.miller-columns__column--active {
+    display: inline-block; }
+  @media (min-width: 40.0625em) {
+    .miller-columns__column {
+      display: inline-block;
+      width: 33.3%;
+      border-right: 1px solid #b1b4b6; } }
 
 .miller-columns__column--narrow {
   width: 16.6%;
@@ -1390,6 +1458,16 @@
 
 .miller-columns__column--collapse {
   display: none; }
+
+.miller-columns__column-heading {
+  padding: 0; }
+  @media (min-width: 40.0625em) {
+    .miller-columns__column-heading {
+      display: none; } }
+
+.miller-columns__column-list {
+  margin: 0;
+  padding: 0; }
 
 .miller-columns__item {
   position: relative;
@@ -1499,3 +1577,16 @@
 
 .miller-columns .govuk-list .govuk-list {
   margin-left: 30px; }
+
+.miller-columns .govuk-back-link {
+  margin-bottom: 20px;
+  padding-top: 0;
+  padding-right: 0;
+  padding-bottom: 0;
+  border-top: 0;
+  border-right: 0;
+  border-left: 0;
+  background: transparent; }
+  @media (min-width: 40.0625em) {
+    .miller-columns .govuk-back-link {
+      display: none; } }

--- a/dist/miller-columns.css
+++ b/dist/miller-columns.css
@@ -1,15 +1,18 @@
-.govuk-error-message {
+.govuk-heading-xl {
+  color: #0b0c0c;
   font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-weight: 700;
-  font-size: 16px;
-  font-size: 1rem;
-  line-height: 1.25;
+  font-size: 32px;
+  font-size: 2rem;
+  line-height: 1.09375;
   display: block;
-  margin-bottom: 15px;
-  clear: both;
-  color: #d4351c; }
+  margin-top: 0;
+  margin-bottom: 30px; }
+  @media print {
+    .govuk-heading-xl {
+      color: #000000; } }
 
 /*! Copyright (c) 2011 by Margaret Calvert & Henrik Kubel. All rights reserved. The font has been customised for exclusive use on gov.uk. This cut is not commercially available. */
 @font-face {
@@ -25,6 +28,355 @@
   font-weight: bold;
   font-style: normal;
   font-display: fallback; }
+  @media print {
+    .govuk-heading-xl {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-heading-xl {
+      font-size: 48px;
+      font-size: 3rem;
+      line-height: 1.04167; } }
+  @media print {
+    .govuk-heading-xl {
+      font-size: 32pt;
+      line-height: 1.15; } }
+  @media (min-width: 40.0625em) {
+    .govuk-heading-xl {
+      margin-bottom: 50px; } }
+
+.govuk-heading-l {
+  color: #0b0c0c;
+  font-family: "GDS Transport", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 24px;
+  font-size: 1.5rem;
+  line-height: 1.04167;
+  display: block;
+  margin-top: 0;
+  margin-bottom: 20px; }
+  @media print {
+    .govuk-heading-l {
+      color: #000000; } }
+  @media print {
+    .govuk-heading-l {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-heading-l {
+      font-size: 36px;
+      font-size: 2.25rem;
+      line-height: 1.11111; } }
+  @media print {
+    .govuk-heading-l {
+      font-size: 24pt;
+      line-height: 1.05; } }
+  @media (min-width: 40.0625em) {
+    .govuk-heading-l {
+      margin-bottom: 30px; } }
+
+.govuk-heading-m {
+  color: #0b0c0c;
+  font-family: "GDS Transport", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 18px;
+  font-size: 1.125rem;
+  line-height: 1.11111;
+  display: block;
+  margin-top: 0;
+  margin-bottom: 15px; }
+  @media print {
+    .govuk-heading-m {
+      color: #000000; } }
+  @media print {
+    .govuk-heading-m {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-heading-m {
+      font-size: 24px;
+      font-size: 1.5rem;
+      line-height: 1.25; } }
+  @media print {
+    .govuk-heading-m {
+      font-size: 18pt;
+      line-height: 1.15; } }
+  @media (min-width: 40.0625em) {
+    .govuk-heading-m {
+      margin-bottom: 20px; } }
+
+.govuk-heading-s, .miller-columns__column-heading {
+  color: #0b0c0c;
+  font-family: "GDS Transport", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.25;
+  display: block;
+  margin-top: 0;
+  margin-bottom: 15px; }
+  @media print {
+    .govuk-heading-s, .miller-columns__column-heading {
+      color: #000000; } }
+  @media print {
+    .govuk-heading-s, .miller-columns__column-heading {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-heading-s, .miller-columns__column-heading {
+      font-size: 19px;
+      font-size: 1.1875rem;
+      line-height: 1.31579; } }
+  @media print {
+    .govuk-heading-s, .miller-columns__column-heading {
+      font-size: 14pt;
+      line-height: 1.15; } }
+  @media (min-width: 40.0625em) {
+    .govuk-heading-s, .miller-columns__column-heading {
+      margin-bottom: 20px; } }
+
+.govuk-caption-xl {
+  font-family: "GDS Transport", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 18px;
+  font-size: 1.125rem;
+  line-height: 1.11111;
+  display: block;
+  margin-bottom: 5px;
+  color: #6f777b; }
+  @media print {
+    .govuk-caption-xl {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-caption-xl {
+      font-size: 27px;
+      font-size: 1.6875rem;
+      line-height: 1.11111; } }
+  @media print {
+    .govuk-caption-xl {
+      font-size: 18pt;
+      line-height: 1.15; } }
+
+.govuk-caption-l {
+  font-family: "GDS Transport", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 18px;
+  font-size: 1.125rem;
+  line-height: 1.11111;
+  display: block;
+  margin-bottom: 5px;
+  color: #6f777b; }
+  @media print {
+    .govuk-caption-l {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-caption-l {
+      font-size: 24px;
+      font-size: 1.5rem;
+      line-height: 1.25; } }
+  @media print {
+    .govuk-caption-l {
+      font-size: 18pt;
+      line-height: 1.15; } }
+  @media (min-width: 40.0625em) {
+    .govuk-caption-l {
+      margin-bottom: 0; } }
+
+.govuk-caption-m {
+  font-family: "GDS Transport", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.25;
+  display: block;
+  color: #6f777b; }
+  @media print {
+    .govuk-caption-m {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-caption-m {
+      font-size: 19px;
+      font-size: 1.1875rem;
+      line-height: 1.31579; } }
+  @media print {
+    .govuk-caption-m {
+      font-size: 14pt;
+      line-height: 1.15; } }
+
+.govuk-body-l, .govuk-body-lead {
+  color: #0b0c0c;
+  font-family: "GDS Transport", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 18px;
+  font-size: 1.125rem;
+  line-height: 1.11111;
+  margin-top: 0;
+  margin-bottom: 20px; }
+  @media print {
+    .govuk-body-l, .govuk-body-lead {
+      color: #000000; } }
+  @media print {
+    .govuk-body-l, .govuk-body-lead {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-body-l, .govuk-body-lead {
+      font-size: 24px;
+      font-size: 1.5rem;
+      line-height: 1.25; } }
+  @media print {
+    .govuk-body-l, .govuk-body-lead {
+      font-size: 18pt;
+      line-height: 1.15; } }
+  @media (min-width: 40.0625em) {
+    .govuk-body-l, .govuk-body-lead {
+      margin-bottom: 30px; } }
+
+.govuk-body-m, .govuk-body {
+  color: #0b0c0c;
+  font-family: "GDS Transport", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.25;
+  margin-top: 0;
+  margin-bottom: 15px; }
+  @media print {
+    .govuk-body-m, .govuk-body {
+      color: #000000; } }
+  @media print {
+    .govuk-body-m, .govuk-body {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-body-m, .govuk-body {
+      font-size: 19px;
+      font-size: 1.1875rem;
+      line-height: 1.31579; } }
+  @media print {
+    .govuk-body-m, .govuk-body {
+      font-size: 14pt;
+      line-height: 1.15; } }
+  @media (min-width: 40.0625em) {
+    .govuk-body-m, .govuk-body {
+      margin-bottom: 20px; } }
+
+.govuk-body-s {
+  color: #0b0c0c;
+  font-family: "GDS Transport", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 14px;
+  font-size: 0.875rem;
+  line-height: 1.14286;
+  margin-top: 0;
+  margin-bottom: 15px; }
+  @media print {
+    .govuk-body-s {
+      color: #000000; } }
+  @media print {
+    .govuk-body-s {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-body-s {
+      font-size: 16px;
+      font-size: 1rem;
+      line-height: 1.25; } }
+  @media print {
+    .govuk-body-s {
+      font-size: 14pt;
+      line-height: 1.2; } }
+  @media (min-width: 40.0625em) {
+    .govuk-body-s {
+      margin-bottom: 20px; } }
+
+.govuk-body-xs {
+  color: #0b0c0c;
+  font-family: "GDS Transport", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 12px;
+  font-size: 0.75rem;
+  line-height: 1.25;
+  margin-top: 0;
+  margin-bottom: 15px; }
+  @media print {
+    .govuk-body-xs {
+      color: #000000; } }
+  @media print {
+    .govuk-body-xs {
+      font-family: sans-serif; } }
+  @media (min-width: 40.0625em) {
+    .govuk-body-xs {
+      font-size: 14px;
+      font-size: 0.875rem;
+      line-height: 1.42857; } }
+  @media print {
+    .govuk-body-xs {
+      font-size: 12pt;
+      line-height: 1.2; } }
+  @media (min-width: 40.0625em) {
+    .govuk-body-xs {
+      margin-bottom: 20px; } }
+
+.govuk-body-l + .govuk-heading-l, .govuk-body-lead + .govuk-heading-l {
+  padding-top: 5px; }
+  @media (min-width: 40.0625em) {
+    .govuk-body-l + .govuk-heading-l, .govuk-body-lead + .govuk-heading-l {
+      padding-top: 10px; } }
+
+.govuk-body-m + .govuk-heading-l, .govuk-body + .govuk-heading-l,
+.govuk-body-s + .govuk-heading-l {
+  padding-top: 15px; }
+  @media (min-width: 40.0625em) {
+    .govuk-body-m + .govuk-heading-l, .govuk-body + .govuk-heading-l,
+    .govuk-body-s + .govuk-heading-l {
+      padding-top: 20px; } }
+
+.govuk-body-m + .govuk-heading-m, .govuk-body + .govuk-heading-m,
+.govuk-body-s + .govuk-heading-m,
+.govuk-body-m + .govuk-heading-s,
+.govuk-body + .govuk-heading-s,
+.govuk-body-m + .miller-columns__column-heading,
+.govuk-body + .miller-columns__column-heading,
+.govuk-body-s + .govuk-heading-s,
+.govuk-body-s + .miller-columns__column-heading {
+  padding-top: 5px; }
+  @media (min-width: 40.0625em) {
+    .govuk-body-m + .govuk-heading-m, .govuk-body + .govuk-heading-m,
+    .govuk-body-s + .govuk-heading-m,
+    .govuk-body-m + .govuk-heading-s,
+    .govuk-body + .govuk-heading-s,
+    .govuk-body-m + .miller-columns__column-heading,
+    .govuk-body + .miller-columns__column-heading,
+    .govuk-body-s + .govuk-heading-s,
+    .govuk-body-s + .miller-columns__column-heading {
+      padding-top: 10px; } }
+
+.govuk-error-message {
+  font-family: "GDS Transport", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.25;
+  display: block;
+  margin-bottom: 15px;
+  clear: both;
+  color: #d4351c; }
   @media print {
     .govuk-error-message {
       font-family: sans-serif; } }
@@ -490,6 +842,62 @@
   .govuk-checkboxes--small .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
     box-shadow: 0 0 0 3px #ffdd00; } }
 
+.govuk-back-link {
+  font-size: 14px;
+  font-size: 0.875rem;
+  line-height: 1.14286;
+  font-family: "GDS Transport", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  display: inline-block;
+  position: relative;
+  margin-top: 15px;
+  margin-bottom: 15px;
+  padding-left: 14px;
+  border-bottom: 1px solid #0b0c0c;
+  text-decoration: none; }
+  @media (min-width: 40.0625em) {
+    .govuk-back-link {
+      font-size: 16px;
+      font-size: 1rem;
+      line-height: 1.25; } }
+  @media print {
+    .govuk-back-link {
+      font-size: 14pt;
+      line-height: 1.2; } }
+  @media print {
+    .govuk-back-link {
+      font-family: sans-serif; } }
+  .govuk-back-link:focus {
+    outline: 3px solid transparent;
+    color: #0b0c0c;
+    background-color: #ffdd00;
+    box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+    text-decoration: none; }
+  .govuk-back-link:link, .govuk-back-link:visited, .govuk-back-link:hover, .govuk-back-link:active, .govuk-back-link:focus {
+    color: #0b0c0c; }
+    @media print {
+      .govuk-back-link:link, .govuk-back-link:visited, .govuk-back-link:hover, .govuk-back-link:active, .govuk-back-link:focus {
+        color: #000000; } }
+  .govuk-back-link:focus {
+    border-bottom-color: transparent; }
+  .govuk-back-link:before {
+    display: block;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-color: transparent;
+    -webkit-clip-path: polygon(0% 50%, 100% 100%, 100% 0%);
+    clip-path: polygon(0% 50%, 100% 100%, 100% 0%);
+    border-width: 5px 6px 5px 0;
+    border-right-color: inherit;
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    margin: auto; }
+
 .govuk-breadcrumbs {
   font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -680,16 +1088,20 @@
       margin-bottom: 30px; } }
 
 .miller-columns__column {
-  display: inline-block;
-  width: 33.3%;
+  display: none;
+  width: 100%;
   height: 100%;
-  margin: 0;
-  padding: 0;
-  border-right: 1px solid #b1b4b6;
   vertical-align: top;
   white-space: normal;
   transition-duration: 400ms;
   transition-property: width; }
+  .miller-columns__column.miller-columns__column--active {
+    display: inline-block; }
+  @media (min-width: 40.0625em) {
+    .miller-columns__column {
+      display: inline-block;
+      width: 33.3%;
+      border-right: 1px solid #b1b4b6; } }
 
 .miller-columns__column--narrow {
   width: 16.6%;
@@ -711,6 +1123,16 @@
 
 .miller-columns__column--collapse {
   display: none; }
+
+.miller-columns__column-heading {
+  padding: 0; }
+  @media (min-width: 40.0625em) {
+    .miller-columns__column-heading {
+      display: none; } }
+
+.miller-columns__column-list {
+  margin: 0;
+  padding: 0; }
 
 .miller-columns__item {
   position: relative;
@@ -820,3 +1242,16 @@
 
 .miller-columns .govuk-list .govuk-list {
   margin-left: 30px; }
+
+.miller-columns .govuk-back-link {
+  margin-bottom: 20px;
+  padding-top: 0;
+  padding-right: 0;
+  padding-bottom: 0;
+  border-top: 0;
+  border-right: 0;
+  border-left: 0;
+  background: transparent; }
+  @media (min-width: 40.0625em) {
+    .miller-columns .govuk-back-link {
+      display: none; } }

--- a/examples/checkboxes-checked.html
+++ b/examples/checkboxes-checked.html
@@ -2,6 +2,7 @@
 <html lang="en" class="govuk-template">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>miller-columns examples</title>
   <link href="../dist/main.css" rel="stylesheet">
   <script src="https://unpkg.com/element-closest/browser"></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -2,6 +2,7 @@
 <html lang="en" class="govuk-template">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>miller-columns examples</title>
   <link href="../dist/main.css" rel="stylesheet">
   <script src="https://unpkg.com/element-closest/browser"></script>

--- a/examples/miller-columns-test.html
+++ b/examples/miller-columns-test.html
@@ -2,6 +2,7 @@
 <html lang="en" class="govuk-template">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>govuk-miller-columns examples</title>
   <link href="../dist/miller-columns.css" rel="stylesheet">
   <script src="https://unpkg.com/element-closest/browser"></script>

--- a/index.js
+++ b/index.js
@@ -290,6 +290,8 @@ class MillerColumnsElement extends HTMLElement {
     super()
     this.classNames = {
       column: 'miller-columns__column',
+      columnHeading: 'miller-columns__column-heading',
+      columnList: 'miller-columns__column-list',
       columnCollapse: 'miller-columns__column--collapse',
       columnMedium: 'miller-columns__column--medium',
       columnNarrow: 'miller-columns__column--narrow',
@@ -322,14 +324,30 @@ class MillerColumnsElement extends HTMLElement {
 
   /** Build and insert a column of the taxonomy */
   renderTaxonomyColumn(topics: Array<Topic>, root: boolean = false) {
-    const ul = document.createElement('ul')
-    ul.className = this.classNames.column
-    if (root) {
-      ul.dataset.root = 'true'
-    } else {
-      ul.classList.add(this.classNames.columnCollapse)
+    const div = document.createElement('div')
+
+    if (!root) {
+      const h3 = document.createElement('h3')
+      h3.className = this.classNames.columnHeading
+      const parentTopicName = topics[0].parent ? topics[0].parent.topicName : null
+      if (parentTopicName) {
+        h3.innerHTML = parentTopicName
+      }
+      div.appendChild(h3)
     }
-    this.appendChild(ul)
+
+    const ul = document.createElement('ul')
+    ul.className = this.classNames.columnList
+    div.className = this.classNames.column
+    if (root) {
+      div.dataset.root = 'true'
+    } else {
+      div.classList.add(this.classNames.columnCollapse)
+    }
+    div.appendChild(ul)
+
+    this.appendChild(div)
+
     for (const topic of topics) {
       this.renderTopic(topic, ul)
     }

--- a/index.js
+++ b/index.js
@@ -293,6 +293,7 @@ class MillerColumnsElement extends HTMLElement {
       columnCollapse: 'miller-columns__column--collapse',
       columnMedium: 'miller-columns__column--medium',
       columnNarrow: 'miller-columns__column--narrow',
+      columnActive: 'miller-columns__column--active',
       item: 'miller-columns__item',
       itemParent: 'miller-columns__item--parent',
       itemActive: 'miller-columns__item--active',
@@ -452,13 +453,19 @@ class MillerColumnsElement extends HTMLElement {
     const narrowThreshold = Math.max(3, columnsToShow.length - 1)
     const showNarrow = columnsToShow.length > narrowThreshold
     const showMedium = showNarrow && narrowThreshold === 3
-    const {columnCollapse: collapseClass, columnNarrow: narrowClass, columnMedium: mediumClass} = this.classNames
+    const {
+      columnCollapse: collapseClass,
+      columnNarrow: narrowClass,
+      columnMedium: mediumClass,
+      columnActive: activeClass
+    } = this.classNames
 
     for (const item of allColumns) {
       if (!item) {
         continue
       }
 
+      item.classList.remove(activeClass)
       // we always want to show the root column
       if (item.dataset.root === 'true') {
         item.classList.remove(narrowClass, mediumClass)
@@ -486,6 +493,11 @@ class MillerColumnsElement extends HTMLElement {
       } else {
         // show this column in all it's glory
         item.classList.remove(collapseClass, narrowClass, mediumClass)
+      }
+
+      // mark last visible column as active
+      if (item === columnsToShow[columnsToShow.length - 1]) {
+        item.classList.add(activeClass)
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -474,6 +474,9 @@ class MillerColumnsElement extends HTMLElement {
         } else if (showNarrow) {
           item.classList.add(narrowClass)
         }
+        if (columnsToShow.length === 0) {
+          item.classList.add(activeClass)
+        }
         continue
       }
 

--- a/index.js
+++ b/index.js
@@ -291,6 +291,7 @@ class MillerColumnsElement extends HTMLElement {
     this.classNames = {
       column: 'miller-columns__column',
       columnHeading: 'miller-columns__column-heading',
+      backLink: 'govuk-back-link',
       columnList: 'miller-columns__column-list',
       columnCollapse: 'miller-columns__column--collapse',
       columnMedium: 'miller-columns__column--medium',
@@ -327,6 +328,23 @@ class MillerColumnsElement extends HTMLElement {
     const div = document.createElement('div')
 
     if (!root) {
+      // Append back link
+      const backLink = document.createElement('button')
+      backLink.className = this.classNames.backLink
+      backLink.type = 'button'
+      backLink.innerHTML = 'Back'
+      backLink.addEventListener(
+        'click',
+        () => {
+          if (topics[0].parent) {
+            this.showCurrentColumns(topics[0].parent.parent)
+          }
+        },
+        false
+      )
+      div.appendChild(backLink)
+
+      // Append heading
       const h3 = document.createElement('h3')
       h3.className = this.classNames.columnHeading
       const parentTopicName = topics[0].parent ? topics[0].parent.topicName : null
@@ -336,6 +354,7 @@ class MillerColumnsElement extends HTMLElement {
       div.appendChild(h3)
     }
 
+    // Append list
     const ul = document.createElement('ul')
     ul.className = this.classNames.columnList
     div.className = this.classNames.column
@@ -346,6 +365,7 @@ class MillerColumnsElement extends HTMLElement {
     }
     div.appendChild(ul)
 
+    // Append column
     this.appendChild(div)
 
     for (const topic of topics) {

--- a/miller-columns.scss
+++ b/miller-columns.scss
@@ -34,16 +34,23 @@ $mc-active-item-background: govuk-colour("blue");
 }
 
 .miller-columns__column {
-  display: inline-block;
-  width: 33.3%;
+  display: none;
+  width: 100%;
   height: 100%;
-  margin: 0;
-  padding: 0;
-  border-right: 1px solid $govuk-border-colour;
   vertical-align: top;
   white-space: normal;
   transition-duration: $mc-transition-time;
   transition-property: width;
+
+  &.miller-columns__column--active {
+    display: inline-block;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    display: inline-block;
+    width: 33.3%;
+    border-right: 1px solid $govuk-border-colour;
+  }
 }
 
 .miller-columns__column--narrow {

--- a/miller-columns.scss
+++ b/miller-columns.scss
@@ -1,3 +1,4 @@
+@import "node_modules/govuk-frontend/govuk/core/typography";
 @import "node_modules/govuk-frontend/govuk/settings/all";
 @import "node_modules/govuk-frontend/govuk/tools/all";
 @import "node_modules/govuk-frontend/govuk/helpers/all";
@@ -83,6 +84,20 @@ $mc-active-item-background: govuk-colour("blue");
 
 .miller-columns__column--collapse {
   display: none;
+}
+
+.miller-columns__column-heading {
+  @extend %govuk-heading-s;
+  padding: 2px 9px;
+
+  @include govuk-media-query($from: tablet) {
+    display: none;
+  }
+}
+
+.miller-columns__column-list {
+  margin: 0;
+  padding: 0;
 }
 
 .miller-columns__item {

--- a/miller-columns.scss
+++ b/miller-columns.scss
@@ -3,6 +3,7 @@
 @import "node_modules/govuk-frontend/govuk/tools/all";
 @import "node_modules/govuk-frontend/govuk/helpers/all";
 @import "node_modules/govuk-frontend/govuk/components/checkboxes/checkboxes";
+@import "node_modules/govuk-frontend/govuk/components/back-link/back-link";
 @import "miller-columns-selected";
 
 $mc-transition-time: 400ms;
@@ -88,7 +89,7 @@ $mc-active-item-background: govuk-colour("blue");
 
 .miller-columns__column-heading {
   @extend %govuk-heading-s;
-  padding: 2px 9px;
+  padding: 0;
 
   @include govuk-media-query($from: tablet) {
     display: none;
@@ -186,6 +187,21 @@ $mc-active-item-background: govuk-colour("blue");
   .govuk-list {
     .govuk-list {
       margin-left: govuk-spacing(6);
+    }
+  }
+
+  .govuk-back-link {
+    margin-bottom: govuk-spacing(4);
+    padding-top: 0;
+    padding-right: 0;
+    padding-bottom: 0;
+    border-top: 0;
+    border-right: 0;
+    border-left: 0;
+    background: transparent;
+
+    @include govuk-media-query($from: tablet) {
+      display: none;
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4005,9 +4005,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.2.0.tgz",
-      "integrity": "sha512-OtJozAGMEKFu195fNVVrQHUX7+znCkA4cXDKs4lgFlRQOTzN1ogT9010GBARuoTwbeL0VqQ8nerZYjVxH/wafA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.3.0.tgz",
+      "integrity": "sha512-ncOGTAV6mzz1CPBlr/UGETiG3IO6P3b0CvSI0wxBz7Uo0A/6jttLoxkvuYXju2oNA2yqRh2NjD1zJUOP3Q32CQ==",
       "dev": true
     },
     "graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "watch": {
     "build": [
       "index.js",
-      "main.scss"
+      "main.scss",
+      "miller-columns.scss",
+      "miller-columns-selected.scss"
     ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint": "^5.16.0",
     "eslint-plugin-github": "1.0.0",
     "flow-bin": "^0.75.0",
-    "govuk-frontend": "^3.2.0",
+    "govuk-frontend": "^3.3.0",
     "karma": "^4.1.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",

--- a/test/test.js
+++ b/test/test.js
@@ -261,6 +261,19 @@ describe('miller-columns', function() {
       const headingL2 = secondColumn.querySelector('.miller-columns__column-heading')
       assert.isTrue(firstLabelL1.textContent.includes(headingL2.textContent))
     })
+
+    it('shows previous column when back link button is clicked', function() {
+      const firstColumn = document.querySelectorAll('.miller-columns__column')[0]
+      const firstItemL1 = firstColumn.querySelector('li')
+      const secondColumn = document.querySelectorAll('.miller-columns__column')[1]
+      const backButtonL2 = secondColumn.querySelector('.govuk-back-link')
+
+      firstItemL1.click()
+      assert.equal(document.querySelector('.miller-columns__column--active'), secondColumn)
+
+      backButtonL2.click()
+      assert.equal(document.querySelector('.miller-columns__column--active'), firstColumn)
+    })
   })
 
   describe('when loading pre-selected items', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -142,15 +142,15 @@ describe('miller-columns', function() {
 
     it('show the child list for active list item', function() {
       const firstItem = document.querySelector('ul li')
-      const l2List = document.querySelectorAll('ul')[1]
+      const l2List = document.querySelectorAll('.miller-columns__column')[1]
       assert.isTrue(l2List.classList.contains('miller-columns__column--collapse'))
       firstItem.click()
       assert.isFalse(l2List.classList.contains('miller-columns__column--collapse'))
     })
 
     it('unselect children when item is unselected', function() {
-      const firstItemL1 = document.querySelector('ul:nth-of-type(1) li')
-      const firstItemL2 = document.querySelector('ul:nth-of-type(2) li')
+      const firstItemL1 = document.querySelector('.miller-columns__column:nth-of-type(1) li')
+      const firstItemL2 = document.querySelector('.miller-columns__column:nth-of-type(2) li')
       firstItemL1.click()
       firstItemL2.click()
       firstItemL1.click()
@@ -160,9 +160,11 @@ describe('miller-columns', function() {
     })
 
     it("doesn't unselect items above the item that was clicked in the tree", function() {
-      const firstItemL1 = document.querySelector('ul:nth-of-type(1) li')
+      const firstItemL1 = document.querySelector('.miller-columns__column:nth-of-type(1) li')
       firstItemL1.click()
-      const firstItemL2 = document.querySelector('ul:not(.miller-columns__column--collapse):nth-of-type(2) li')
+      const firstItemL2 = document.querySelector(
+        '.miller-columns__column:not(.miller-columns__column--collapse):nth-of-type(2) li'
+      )
       firstItemL2.click()
 
       firstItemL2.click()
@@ -174,9 +176,9 @@ describe('miller-columns', function() {
     })
 
     it('shows active items in selected items', function() {
-      const firstItemL1 = document.querySelector('ul:nth-of-type(1) li')
+      const firstItemL1 = document.querySelector('.miller-columns__column:nth-of-type(1) li')
       const firstLabelL1 = firstItemL1.querySelector('label')
-      const firstItemL2 = document.querySelector('ul:nth-of-type(2) li')
+      const firstItemL2 = document.querySelector('.miller-columns__column:nth-of-type(2) li')
       const firstLabelL2 = firstItemL2.querySelector('label')
       firstItemL1.click()
       firstItemL2.click()
@@ -187,7 +189,7 @@ describe('miller-columns', function() {
     })
 
     it('removes a chain from stored selected items', function() {
-      const firstItemL1 = document.querySelector('ul li')
+      const firstItemL1 = document.querySelector('.miller-columns__column li')
       const millerColumnsSelected = document.querySelector('miller-columns-selected')
       millerColumnsSelected.addEventListener('remove-topic', function(e) {
         assert.equal(e.detail.topicName, "Parenting, childcare and children's services")
@@ -203,9 +205,9 @@ describe('miller-columns', function() {
     })
 
     it('creates entries of selected item for adjacent topics', function() {
-      const firstItemL1 = document.querySelector('ul:nth-child(1) li')
-      const firstItemL2 = document.querySelector('ul:nth-child(2) li:nth-child(1)')
-      const secondItemL2 = document.querySelector('ul:nth-child(2) li:nth-child(2)')
+      const firstItemL1 = document.querySelector('.miller-columns__column:nth-of-type(1) li')
+      const firstItemL2 = document.querySelector('.miller-columns__column:nth-of-type(2) li')
+      const secondItemL2 = document.querySelector('.miller-columns__column:nth-of-type(2) li:nth-of-type(2)')
 
       const firstLabelL2 = firstItemL2.querySelector('label')
       const secondLabelL2 = secondItemL2.querySelector('label')
@@ -239,17 +241,25 @@ describe('miller-columns', function() {
     })
 
     it('shows active column while selecting items', function() {
-      const firstColumn = document.querySelector('ul:nth-of-type(1)')
+      const firstColumn = document.querySelectorAll('.miller-columns__column')[0]
       const firstItemL1 = firstColumn.querySelector('li')
-      const secondColumn = document.querySelector('ul:nth-of-type(2)')
-      const firstItemL2 = secondColumn.querySelector('ul:nth-of-type(2) li')
-      const thirdColumn = document.querySelector('ul:nth-of-type(3)')
+      const secondColumn = document.querySelectorAll('.miller-columns__column')[1]
+      const firstItemL2 = secondColumn.querySelector('li')
+      const thirdColumn = document.querySelectorAll('.miller-columns__column')[2]
 
       assert.equal(document.querySelector('.miller-columns__column--active'), firstColumn)
       firstItemL1.click()
       assert.equal(document.querySelector('.miller-columns__column--active'), secondColumn)
       firstItemL2.click()
       assert.equal(document.querySelector('.miller-columns__column--active'), thirdColumn)
+    })
+
+    it('shows parent element as heading for each column', function() {
+      const firstColumn = document.querySelectorAll('.miller-columns__column')[0]
+      const firstLabelL1 = firstColumn.querySelector('label')
+      const secondColumn = document.querySelectorAll('.miller-columns__column')[1]
+      const headingL2 = secondColumn.querySelector('.miller-columns__column-heading')
+      assert.isTrue(firstLabelL1.textContent.includes(headingL2.textContent))
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -245,6 +245,7 @@ describe('miller-columns', function() {
       const firstItemL2 = secondColumn.querySelector('ul:nth-of-type(2) li')
       const thirdColumn = document.querySelector('ul:nth-of-type(3)')
 
+      assert.equal(document.querySelector('.miller-columns__column--active'), firstColumn)
       firstItemL1.click()
       assert.equal(document.querySelector('.miller-columns__column--active'), secondColumn)
       firstItemL2.click()

--- a/test/test.js
+++ b/test/test.js
@@ -237,6 +237,19 @@ describe('miller-columns', function() {
       const millerColumns = document.querySelector('miller-columns')
       assert.equal(millerColumns.taxonomy.flattenedTopics.length, 6)
     })
+
+    it('shows active column while selecting items', function() {
+      const firstColumn = document.querySelector('ul:nth-of-type(1)')
+      const firstItemL1 = firstColumn.querySelector('li')
+      const secondColumn = document.querySelector('ul:nth-of-type(2)')
+      const firstItemL2 = secondColumn.querySelector('ul:nth-of-type(2) li')
+      const thirdColumn = document.querySelector('ul:nth-of-type(3)')
+
+      firstItemL1.click()
+      assert.equal(document.querySelector('.miller-columns__column--active'), secondColumn)
+      firstItemL2.click()
+      assert.equal(document.querySelector('.miller-columns__column--active'), thirdColumn)
+    })
   })
 
   describe('when loading pre-selected items', function() {


### PR DESCRIPTION
This PR updates the way miller-columns-element is behaving on mobile/small screens.

**Chore**
- Update `govuk-frontend` to the latest version (3.3.0)
- Watch missing SCSS file

**Changes**
- Mark the active column with a CSS modifier (and use that to only show the active column on mobile)
- Add a heading to each column (on mobile) to show context
- Add back button (on mobile) to allow upstream navigation
- Update dist to reflect changes

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

<img width="500" alt="Screenshot 2019-11-26 at 10 38 03" src="https://user-images.githubusercontent.com/788096/69622534-0584f000-1039-11ea-80dc-6db16a62997f.png">

</td><td>

<img width="500" alt="Screenshot 2019-11-26 at 10 37 19" src="https://user-images.githubusercontent.com/788096/69622539-07e74a00-1039-11ea-9ca1-d9075d36f6ca.png">

</td></tr>
</table>

[Trello card](https://trello.com/c/ApHlPUDQ)