### PR TITLE
Release clean up

### DIFF
--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -819,7 +819,7 @@ var MillerColumnsElement = function (_CustomElement2) {
             item.classList.remove(collapseClass, narrowClass, mediumClass);
           }
 
-          // mark last column as active
+          // mark last visible column as active
           if (item === columnsToShow[columnsToShow.length - 1]) {
             item.classList.add(activeClass);
           }

--- a/dist/index.umd.js
+++ b/dist/index.umd.js
@@ -806,7 +806,7 @@
               item.classList.remove(collapseClass, narrowClass, mediumClass);
             }
 
-            // mark last column as active
+            // mark last visible column as active
             if (item === columnsToShow[columnsToShow.length - 1]) {
               item.classList.add(activeClass);
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "miller-columns-element",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This is a clean-up PR after 1.2.0 release:
- `npm install` revealed the version number was no updated in `package-lock.json`
- `npm run build` revealed an updated comment was missing from the `dist` files