### PR TITLE
Fix active column on root taxons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Fix active column on root taxons (PR #30)
+
 ## 1.2.1
 
 - Improve remove action for screen readers (PR #28)

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -764,7 +764,7 @@ var MillerColumnsElement = function (_CustomElement2) {
     key: 'showCurrentColumns',
     value: function showCurrentColumns(activeTopic) {
       var allColumns = nodesToArray(this.getElementsByClassName(this.classNames.column));
-      var columnsToShow = this.columnsForActiveTopic(activeTopic);
+      var columnsToShow = activeTopic ? this.columnsForActiveTopic(activeTopic) : [allColumns[0]];
       var narrowThreshold = Math.max(3, columnsToShow.length - 1);
       var showNarrow = columnsToShow.length > narrowThreshold;
       var showMedium = showNarrow && narrowThreshold === 3;
@@ -795,7 +795,7 @@ var MillerColumnsElement = function (_CustomElement2) {
             } else if (showNarrow) {
               item.classList.add(narrowClass);
             }
-            if (columnsToShow.length === 0) {
+            if (columnsToShow.length === 1) {
               item.classList.add(activeClass);
             }
             continue;

--- a/dist/index.umd.js
+++ b/dist/index.umd.js
@@ -751,7 +751,7 @@
       key: 'showCurrentColumns',
       value: function showCurrentColumns(activeTopic) {
         var allColumns = nodesToArray(this.getElementsByClassName(this.classNames.column));
-        var columnsToShow = this.columnsForActiveTopic(activeTopic);
+        var columnsToShow = activeTopic ? this.columnsForActiveTopic(activeTopic) : [allColumns[0]];
         var narrowThreshold = Math.max(3, columnsToShow.length - 1);
         var showNarrow = columnsToShow.length > narrowThreshold;
         var showMedium = showNarrow && narrowThreshold === 3;
@@ -782,7 +782,7 @@
               } else if (showNarrow) {
                 item.classList.add(narrowClass);
               }
-              if (columnsToShow.length === 0) {
+              if (columnsToShow.length === 1) {
                 item.classList.add(activeClass);
               }
               continue;

--- a/index.js
+++ b/index.js
@@ -487,7 +487,7 @@ class MillerColumnsElement extends HTMLElement {
   /** Change what columns are visible based on the active (or not) topic */
   showCurrentColumns(activeTopic: ?Topic) {
     const allColumns = nodesToArray(this.getElementsByClassName(this.classNames.column))
-    const columnsToShow = this.columnsForActiveTopic(activeTopic)
+    const columnsToShow = activeTopic ? this.columnsForActiveTopic(activeTopic) : [allColumns[0]]
     const narrowThreshold = Math.max(3, columnsToShow.length - 1)
     const showNarrow = columnsToShow.length > narrowThreshold
     const showMedium = showNarrow && narrowThreshold === 3
@@ -512,7 +512,7 @@ class MillerColumnsElement extends HTMLElement {
         } else if (showNarrow) {
           item.classList.add(narrowClass)
         }
-        if (columnsToShow.length === 0) {
+        if (columnsToShow.length === 1) {
           item.classList.add(activeClass)
         }
         continue

--- a/test/test.js
+++ b/test/test.js
@@ -79,6 +79,14 @@ describe('miller-columns', function() {
                 </li>
              </ul>
           </li>
+          <li>
+             <div class="govuk-checkboxes__item">
+                <input type="checkbox" id="topic-206b7f3a-49b5-476f-af0f-fd27e2a68474" class="govuk-checkboxes__input" name="topics[]" value="206b7f3a-49b5-476f-af0f-fd27e2a68474" tabindex="-1">
+                <label for="topic-206b7f3a-49b5-476f-af0f-fd27e2a68474" class="govuk-label govuk-checkboxes__label">
+                Corporate information
+                </label>
+             </div>
+          </li>
           </ul>
         </miller-columns>
       `
@@ -239,12 +247,13 @@ describe('miller-columns', function() {
 
     it('provides an API to access all topics in a flat list', function() {
       const millerColumns = document.querySelector('miller-columns')
-      assert.equal(millerColumns.taxonomy.flattenedTopics.length, 6)
+      assert.equal(millerColumns.taxonomy.flattenedTopics.length, 7)
     })
 
     it('shows active column while selecting items', function() {
       const firstColumn = document.querySelectorAll('.miller-columns__column')[0]
       const firstItemL1 = firstColumn.querySelector('li')
+      const secondItemL1 = firstColumn.querySelector('li:nth-of-type(2)')
       const secondColumn = document.querySelectorAll('.miller-columns__column')[1]
       const firstItemL2 = secondColumn.querySelector('li')
       const thirdColumn = document.querySelectorAll('.miller-columns__column')[2]
@@ -254,6 +263,8 @@ describe('miller-columns', function() {
       assert.equal(document.querySelector('.miller-columns__column--active'), secondColumn)
       firstItemL2.click()
       assert.equal(document.querySelector('.miller-columns__column--active'), thirdColumn)
+      secondItemL1.click()
+      assert.equal(document.querySelector('.miller-columns__column--active'), firstColumn)
     })
 
     it('shows parent element as heading for each column', function() {


### PR DESCRIPTION
Currently, the first column (the one holding the root taxons) only has the active class added to it initially (when to taxon is selected). This PR updates the code so that the active class is added to the first column when a root taxon is selected and doesn't have any children taxons to go down to.

[Trello card](https://trello.com/c/XwOunNTh)