### PR TITLE
Enable navigation instructions for assistive technologies

### DIFF
--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -514,6 +514,8 @@ var MillerColumnsElement = function (_CustomElement2) {
   _createClass(MillerColumnsElement, [{
     key: 'connectedCallback',
     value: function connectedCallback() {
+      this.describedbyId = this.getAttribute('aria-describedby');
+
       var source = document.getElementById(this.getAttribute('for') || '');
       if (source) {
         this.taxonomy = new Taxonomy(Topic.fromList(source), this);
@@ -611,6 +613,10 @@ var MillerColumnsElement = function (_CustomElement2) {
       var li = document.createElement('li');
       li.classList.add(this.classNames.item);
       li.classList.add('govuk-checkboxes--small');
+      if (this.describedbyId) {
+        li.setAttribute('aria-describedby', this.describedbyId);
+      }
+
       var div = document.createElement('div');
       div.className = 'govuk-checkboxes__item';
       div.appendChild(topic.checkbox);

--- a/dist/index.umd.js
+++ b/dist/index.umd.js
@@ -568,6 +568,8 @@
     _createClass(MillerColumnsElement, [{
       key: 'connectedCallback',
       value: function connectedCallback() {
+        this.describedbyId = this.getAttribute('aria-describedby');
+
         var source = document.getElementById(this.getAttribute('for') || '');
         if (source) {
           this.taxonomy = new Taxonomy(Topic.fromList(source), this);
@@ -656,6 +658,10 @@
         var li = document.createElement('li');
         li.classList.add(this.classNames.item);
         li.classList.add('govuk-checkboxes--small');
+        if (this.describedbyId) {
+          li.setAttribute('aria-describedby', this.describedbyId);
+        }
+
         var div = document.createElement('div');
         div.className = 'govuk-checkboxes__item';
         div.appendChild(topic.checkbox);

--- a/dist/main.css
+++ b/dist/main.css
@@ -1566,7 +1566,7 @@
     box-shadow: none; }
 
 .miller-columns__item--parent:after {
-  content: "\203A";
+  content: "\203A" / "";
   position: absolute;
   top: 50%;
   right: 5px;

--- a/dist/miller-columns.css
+++ b/dist/miller-columns.css
@@ -1231,7 +1231,7 @@
     box-shadow: none; }
 
 .miller-columns__item--parent:after {
-  content: "\203A";
+  content: "\203A" / "";
   position: absolute;
   top: 50%;
   right: 5px;

--- a/examples/checkboxes-checked.html
+++ b/examples/checkboxes-checked.html
@@ -18,8 +18,9 @@
       <h1 class="govuk-heading-xl">miller-columns element</h1>
       <p class="govuk-body">Express a hierarchy by showing selectable lists of the items in each hierarchy level.<br/>Selection of any item shows that item’s children in the next list.</p>
       <h2 class="govuk-heading-m">Selected topics</h2>
+      <p id="navigation-instructions" class="govuk-body govuk-visually-hidden">Use the right arrow to explore sub-topics, use the up and down arrows to find other topics.</p>
       <miller-columns-selected class="miller-columns-selected" id="selected-items" for="miller-columns"></miller-columns-selected>
-      <miller-columns id="miller-columns" class="miller-columns" for="taxonomy" selected="selected-items">
+      <miller-columns id="miller-columns" class="miller-columns" for="taxonomy" selected="selected-items" aria-describedby="navigation-instructions">
         <ul id="taxonomy" class="govuk-list">
           <li>
             <div class="govuk-checkboxes__item">

--- a/examples/index.html
+++ b/examples/index.html
@@ -18,8 +18,9 @@
       <h1 class="govuk-heading-xl">miller-columns element</h1>
       <p class="govuk-body">Express a hierarchy by showing selectable lists of the items in each hierarchy level.<br/>Selection of any item shows that item’s children in the next list.</p>
       <h2 class="govuk-heading-m">Selected topics</h2>
+      <p id="navigation-instructions" class="govuk-body govuk-visually-hidden">Use the right arrow to explore sub-topics, use the up and down arrows to find other topics.</p>
       <miller-columns-selected class="miller-columns-selected" id="selected-items" for="miller-columns"></miller-columns-selected>
-      <miller-columns id="miller-columns" class="miller-columns" for="taxonomy" selected="selected-items">
+      <miller-columns id="miller-columns" class="miller-columns" for="taxonomy" selected="selected-items" aria-describedby="navigation-instructions">
         <ul id="taxonomy" class="govuk-list">
           <li>
             <div class="govuk-checkboxes__item">

--- a/examples/miller-columns-test.html
+++ b/examples/miller-columns-test.html
@@ -13,8 +13,9 @@
   <script>
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
   </script>
+  <p id="navigation-instructions" class="govuk-body govuk-visually-hidden">Use the right arrow to explore sub-topics, use the up and down arrows to find other topics.</p>
   <miller-columns-selected class="miller-columns-selected" id="selected-items" for="miller-columns"></miller-columns-selected>
-  <miller-columns id="miller-columns" class="miller-columns" for="taxonomy" selected="selected-items">
+  <miller-columns id="miller-columns" class="miller-columns" for="taxonomy" selected="selected-items" aria-describedby="navigation-instructions">
     <ul id="taxonomy" class="govuk-list">
     <li>
        <div class="govuk-checkboxes__item">

--- a/index.js
+++ b/index.js
@@ -303,6 +303,7 @@ class Topic {
 class MillerColumnsElement extends HTMLElement {
   taxonomy: Taxonomy
   classNames: Object
+  describedbyId: ?string
 
   constructor() {
     super()
@@ -323,6 +324,8 @@ class MillerColumnsElement extends HTMLElement {
   }
 
   connectedCallback() {
+    this.describedbyId = this.getAttribute('aria-describedby')
+
     const source = document.getElementById(this.getAttribute('for') || '')
     if (source) {
       this.taxonomy = new Taxonomy(Topic.fromList(source), this)
@@ -396,6 +399,10 @@ class MillerColumnsElement extends HTMLElement {
     const li = document.createElement('li')
     li.classList.add(this.classNames.item)
     li.classList.add('govuk-checkboxes--small')
+    if (this.describedbyId) {
+      li.setAttribute('aria-describedby', this.describedbyId)
+    }
+
     const div = document.createElement('div')
     div.className = 'govuk-checkboxes__item'
     div.appendChild(topic.checkbox)

--- a/miller-columns.scss
+++ b/miller-columns.scss
@@ -137,7 +137,7 @@ $mc-active-item-background: govuk-colour("blue");
 }
 
 .miller-columns__item--parent:after {
-  content: "\203A";
+  content: "\203A" / "";
   position: absolute;
   top: 50%;
   right: 5px;

--- a/test/test.js
+++ b/test/test.js
@@ -23,7 +23,8 @@ describe('miller-columns', function() {
       const container = document.createElement('div')
       container.innerHTML = `
         <miller-columns-selected id="selected-items" for="miller-columns"></miller-columns-selected>
-        <miller-columns id="miller-columns" for="taxonomy" selected="selected-items">
+        <p id="navigation-instructions" class="govuk-body govuk-visually-hidden">Use the right arrow to explore sub-topics, use the up and down arrows to find other topics.</p>
+        <miller-columns id="miller-columns" for="taxonomy" selected="selected-items" aria-describedby="navigation-instructions">
           <ul id="taxonomy">
           <li>
              <div class="govuk-checkboxes__item">
@@ -326,6 +327,15 @@ describe('miller-columns', function() {
 
       backButtonL2.click()
       assert.equal(document.querySelector('.miller-columns__column--active'), firstColumn)
+    })
+
+    it('applies aria-describedby to each individual item', function() {
+      const millerColumnsElement = document.querySelector('miller-columns')
+      const describedbyId = millerColumnsElement.getAttribute('aria-describedby')
+
+      const millerColumnsItem = document.querySelector('.miller-columns__item')
+
+      assert.equal(millerColumnsItem.getAttribute('aria-describedby'), describedbyId)
     })
   })
 


### PR DESCRIPTION
- Hides chevron (read as "angle quotation mark") from screen readers
- Applies `aria-describedby` applied to the `<miller-columns>` element to each miller-columns item – this description is being read out after the label for each taxon and it's intended to help screen reader users navigate the taxonomy tree.

Examples below using VoiceOver

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr><td>

<img width="629" alt="Screenshot 2020-02-05 at 17 51 17" src="https://user-images.githubusercontent.com/788096/73868463-65b9be80-4840-11ea-9465-d3e59d6d6567.png">

</td><td>

<img width="648" alt="Screenshot 2020-02-05 at 17 50 51" src="https://user-images.githubusercontent.com/788096/73868486-710cea00-4840-11ea-990e-613dba3bfdb6.png">


</td></tr>
  <tr><td>

<img width="637" alt="Screenshot 2020-02-05 at 17 51 38" src="https://user-images.githubusercontent.com/788096/73868476-6b170900-4840-11ea-96ee-9d900b6fafbf.png">

</td><td>

<img width="642" alt="Screenshot 2020-02-05 at 17 50 25" src="https://user-images.githubusercontent.com/788096/73868494-7407da80-4840-11ea-88a0-3ca7495e807e.png">

</td></tr>
</table>


[Trello card](https://trello.com/c/UvdqcKqr)