### PR TITLE
Use dpl v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ deploy:
   # This deploy requires a Github personal access token, so if this breaks it
   # could be that the developer has left GDS.
   - provider: pages
+    edge: true
     skip_cleanup: true
     github_token: $GITHUB_TOKEN
     keep_history: true
@@ -21,12 +22,14 @@ deploy:
     on:
       branch: master
   - provider: script
+    edge: true
     skip_cleanup: true
     script: git tag $LOCAL_VERSION && git push $GIT_REMOTE --tags
     on:
       branch: master
       condition: -z $GIT_TAG
   - provider: npm
+    edge: true
     skip_cleanup: true
     email: govuk-dev@digital.cabinet-office.gov.uk
     api_key: $NPM_TOKEN


### PR DESCRIPTION
Use [dpl v2](https://docs.travis-ci.com/user/deployment-v2#how-to-opt-in-to-v2) as [Travis is currently failing on master](https://travis-ci.com/alphagov/miller-columns-element/builds/147745210#L383) with "missing api_key".

Issue: https://travis-ci.community/t/missing-api-key-when-deploying-to-github-releases/5761/8