### PR TITLE
Remove checkboxes from focus order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## Unreleased
+
+- Ensure checkboxes are focusable without JS (PR #35)
+
 ## 1.3.0
 
 - Fix active column on root taxons (PR #30)

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -199,6 +199,8 @@ var Topic = function () {
             var childList = item.querySelector('ul');
             childList = childList instanceof HTMLUListElement ? childList : null;
 
+            checkbox.tabIndex = -1;
+
             var previous = index > 0 ? topics[index - 1] : null;
 
             var topic = new Topic(label, checkbox, childList, parent, previous);

--- a/dist/index.umd.js
+++ b/dist/index.umd.js
@@ -279,6 +279,8 @@
               var childList = item.querySelector('ul');
               childList = childList instanceof HTMLUListElement ? childList : null;
 
+              checkbox.tabIndex = -1;
+
               var previous = index > 0 ? topics[index - 1] : null;
 
               var topic = new Topic(label, checkbox, childList, parent, previous);

--- a/examples/checkboxes-checked.html
+++ b/examples/checkboxes-checked.html
@@ -24,37 +24,37 @@
         <ul id="taxonomy" class="govuk-list">
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c0" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c0">
               <label class="govuk-label govuk-checkboxes__label" for="c0">Entering and staying in the UK</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1" tabindex="-1" checked>
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1" checked>
                   <label class="govuk-label govuk-checkboxes__label" for="c1">Travel and identity documents for foreign nationals</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c2" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c2">
                   <label class="govuk-label govuk-checkboxes__label" for="c2">Immigration offences</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c3" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c3">
                       <label class="govuk-label govuk-checkboxes__label" for="c3">Deportation, removals and curtailment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c4" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c4">
                       <label class="govuk-label govuk-checkboxes__label" for="c4">Immigration detention</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c5" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c5">
                       <label class="govuk-label govuk-checkboxes__label" for="c5">Immigration penalties</label>
                     </div>
                   </li>
@@ -62,37 +62,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c6" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c6">
                   <label class="govuk-label govuk-checkboxes__label" for="c6">Immigration adviser services</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c7" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c7">
                   <label class="govuk-label govuk-checkboxes__label" for="c7">Rights of foreign nationals in the UK</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c8" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c8">
                       <label class="govuk-label govuk-checkboxes__label" for="c8">Rights of nationals from outside the EU and EEA</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c9" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c9">
                       <label class="govuk-label govuk-checkboxes__label" for="c9">Foreign nationals working in the UK</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c10" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c10">
                       <label class="govuk-label govuk-checkboxes__label" for="c10">Right to rent in the UK</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c11" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c11">
                       <label class="govuk-label govuk-checkboxes__label" for="c11">Rights of EU and EEA citizens</label>
                     </div>
                   </li>
@@ -100,49 +100,49 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c12" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c12">
                   <label class="govuk-label govuk-checkboxes__label" for="c12">Visas and immigration corporate</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c13" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c13">
                   <label class="govuk-label govuk-checkboxes__label" for="c13">Border control</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c14" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c14">
                   <label class="govuk-label govuk-checkboxes__label" for="c14">Immigration rules</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c15" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c15">
                   <label class="govuk-label govuk-checkboxes__label" for="c15">Refugees, asylum and human rights</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c16" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c16">
                       <label class="govuk-label govuk-checkboxes__label" for="c16">Refugee, asylum and human rights claims</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c17" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c17">
                       <label class="govuk-label govuk-checkboxes__label" for="c17">Asylum decisions and appeals</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c18" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c18">
                       <label class="govuk-label govuk-checkboxes__label" for="c18">Asylum for children</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c19" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c19">
                       <label class="govuk-label govuk-checkboxes__label" for="c19">Support for asylum claimants and refugees</label>
                     </div>
                   </li>
@@ -150,61 +150,61 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c20" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c20">
                   <label class="govuk-label govuk-checkboxes__label" for="c20">Visas and entry clearance</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c21" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c21">
                       <label class="govuk-label govuk-checkboxes__label" for="c21">Work and investor visas</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c22" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c22">
                       <label class="govuk-label govuk-checkboxes__label" for="c22">Visit and transit visas</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c23" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c23">
                       <label class="govuk-label govuk-checkboxes__label" for="c23">Visa application centres</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c24" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c24">
                       <label class="govuk-label govuk-checkboxes__label" for="c24">Visa sponsorship</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c25" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c25">
                       <label class="govuk-label govuk-checkboxes__label" for="c25">Tuberculosis (TB) testing</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c26" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c26">
                       <label class="govuk-label govuk-checkboxes__label" for="c26">Student visas</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c27" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c27">
                       <label class="govuk-label govuk-checkboxes__label" for="c27">Family visas</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c28" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c28">
                       <label class="govuk-label govuk-checkboxes__label" for="c28">Visa refusals and appeals</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c29" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c29">
                       <label class="govuk-label govuk-checkboxes__label" for="c29">Visa applications</label>
                     </div>
                   </li>
@@ -212,19 +212,19 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c30" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c30">
                   <label class="govuk-label govuk-checkboxes__label" for="c30">Permanent stay in the UK</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c31" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c31">
                       <label class="govuk-label govuk-checkboxes__label" for="c31">Citizenship</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c32" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c32">
                       <label class="govuk-label govuk-checkboxes__label" for="c32">Settlement</label>
                     </div>
                   </li>
@@ -234,31 +234,31 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c33" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c33">
               <label class="govuk-label govuk-checkboxes__label" for="c33">Going and being abroad</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c34" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c34">
                   <label class="govuk-label govuk-checkboxes__label" for="c34">Travel abroad</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c35" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c35">
                   <label class="govuk-label govuk-checkboxes__label" for="c35">Passports</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c36" tabindex="-1" checked>
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c36" checked>
                   <label class="govuk-label govuk-checkboxes__label" for="c36">British nationals overseas</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c37" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c37">
                   <label class="govuk-label govuk-checkboxes__label" for="c37">Living abroad</label>
                 </div>
               </li>
@@ -266,67 +266,67 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c38" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c38">
               <label class="govuk-label govuk-checkboxes__label" for="c38">Education, training and skills</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c39" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c39">
                   <label class="govuk-label govuk-checkboxes__label" for="c39">Further and higher education, skills and vocational training</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c40" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c40">
                       <label class="govuk-label govuk-checkboxes__label" for="c40">Further education funding</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c41" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c41">
                           <label class="govuk-label govuk-checkboxes__label" for="c41">Administering student funding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c42" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c42">
                           <label class="govuk-label govuk-checkboxes__label" for="c42">Dance and drama funding for 16 to 19 year olds</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c43" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c43">
                           <label class="govuk-label govuk-checkboxes__label" for="c43">Further education funding data</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c44" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c44">
                           <label class="govuk-label govuk-checkboxes__label" for="c44">Free meals for 16 to 18 year olds</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c45" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c45">
                           <label class="govuk-label govuk-checkboxes__label" for="c45">European Social Fund (ESF) and skills funding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c46" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c46">
                           <label class="govuk-label govuk-checkboxes__label" for="c46">Further education buildings and land</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c47" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c47">
                           <label class="govuk-label govuk-checkboxes__label" for="c47">Apprenticeships funding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c48" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c48">
                           <label class="govuk-label govuk-checkboxes__label" for="c48">Adult education funding</label>
                         </div>
                       </li>
@@ -334,37 +334,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c49" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c49">
                       <label class="govuk-label govuk-checkboxes__label" for="c49">Apprenticeships, traineeships and internships</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c50" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c50">
                           <label class="govuk-label govuk-checkboxes__label" for="c50">Hiring and training an apprentice</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c51" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c51">
                           <label class="govuk-label govuk-checkboxes__label" for="c51">Becoming an apprentice</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c52" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c52">
                           <label class="govuk-label govuk-checkboxes__label" for="c52">Hiring and training an intern or trainee</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c53" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c53">
                           <label class="govuk-label govuk-checkboxes__label" for="c53">Types of apprenticeships</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c54" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c54">
                           <label class="govuk-label govuk-checkboxes__label" for="c54">Becoming an intern or trainee</label>
                         </div>
                       </li>
@@ -372,31 +372,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c55" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c55">
                       <label class="govuk-label govuk-checkboxes__label" for="c55">Adult and community learning</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c56" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c56">
                       <label class="govuk-label govuk-checkboxes__label" for="c56">Careers guidance in further and higher education</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c57" tabindex="-1" checked>
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c57" checked>
                       <label class="govuk-label govuk-checkboxes__label" for="c57">Further and higher education courses and qualifications</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c58" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c58">
                           <label class="govuk-label govuk-checkboxes__label" for="c58">Functional skills</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c59" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c59">
                           <label class="govuk-label govuk-checkboxes__label" for="c59">Principal learning qualifications</label>
                         </div>
                       </li>
@@ -404,25 +404,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c60" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c60">
                       <label class="govuk-label govuk-checkboxes__label" for="c60">Further education financial management and data collection</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c61" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c61">
                           <label class="govuk-label govuk-checkboxes__label" for="c61">Data collection for further education providers</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c62" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c62">
                           <label class="govuk-label govuk-checkboxes__label" for="c62">Local authority further education financial reporting and assurance</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c63" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c63">
                           <label class="govuk-label govuk-checkboxes__label" for="c63">Financial management for further education providers</label>
                         </div>
                       </li>
@@ -430,19 +430,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c64" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c64">
                       <label class="govuk-label govuk-checkboxes__label" for="c64">Running a further or higher education institution</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c65" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c65">
                       <label class="govuk-label govuk-checkboxes__label" for="c65">Learning Records Service (LRS)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c66" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c66">
                       <label class="govuk-label govuk-checkboxes__label" for="c66">Education in prisons</label>
                     </div>
                   </li>
@@ -450,43 +450,43 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c67" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c67">
                   <label class="govuk-label govuk-checkboxes__label" for="c67">Pupil wellbeing, behaviour and attendance</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c68" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c68">
                       <label class="govuk-label govuk-checkboxes__label" for="c68">Safeguarding pupils</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c69" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c69">
                       <label class="govuk-label govuk-checkboxes__label" for="c69">School attendance and absence</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c70" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c70">
                       <label class="govuk-label govuk-checkboxes__label" for="c70">School discipline and exclusions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c71" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c71">
                       <label class="govuk-label govuk-checkboxes__label" for="c71">Health, safety and wellbeing in schools</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c72" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c72">
                       <label class="govuk-label govuk-checkboxes__label" for="c72">School bullying</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c73" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c73">
                       <label class="govuk-label govuk-checkboxes__label" for="c73">Alternative provision and pupil referral units</label>
                     </div>
                   </li>
@@ -494,37 +494,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c74" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c74">
                   <label class="govuk-label govuk-checkboxes__label" for="c74">Teaching and leadership</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c75" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c75">
                       <label class="govuk-label govuk-checkboxes__label" for="c75">Teaching standards, misconduct and practice</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c76" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c76">
                       <label class="govuk-label govuk-checkboxes__label" for="c76">Teacher training and professional development</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c77" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c77">
                           <label class="govuk-label govuk-checkboxes__label" for="c77">School leadership</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c78" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c78">
                           <label class="govuk-label govuk-checkboxes__label" for="c78">Initial Teacher Training (ITT)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c79" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c79">
                           <label class="govuk-label govuk-checkboxes__label" for="c79">Qualified Teacher Status (QTS)</label>
                         </div>
                       </li>
@@ -532,19 +532,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c80" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c80">
                       <label class="govuk-label govuk-checkboxes__label" for="c80">Recruiting, inducting and managing teachers</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c81" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c81">
                       <label class="govuk-label govuk-checkboxes__label" for="c81">Teacher pay, pensions and conditions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c82" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c82">
                       <label class="govuk-label govuk-checkboxes__label" for="c82">Teacher records</label>
                     </div>
                   </li>
@@ -552,73 +552,73 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c83" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c83">
                   <label class="govuk-label govuk-checkboxes__label" for="c83">Inspections and performance of education providers</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c84" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c84">
                       <label class="govuk-label govuk-checkboxes__label" for="c84">Inspection and performance of schools</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c85" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c85">
                           <label class="govuk-label govuk-checkboxes__label" for="c85">School intervention notices and reports</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c86" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c86">
                           <label class="govuk-label govuk-checkboxes__label" for="c86">Inspection of local authority support for schools</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c87" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c87">
                           <label class="govuk-label govuk-checkboxes__label" for="c87">School performance tables and Ofsted reports</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c88" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c88">
                           <label class="govuk-label govuk-checkboxes__label" for="c88">Inspection of maintained schools and academies</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c89" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c89">
                           <label class="govuk-label govuk-checkboxes__label" for="c89">Inspection of boarding and residential schools</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c90" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c90">
                           <label class="govuk-label govuk-checkboxes__label" for="c90">Inspection of non-maintained schools</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c91" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c91">
                           <label class="govuk-label govuk-checkboxes__label" for="c91">Inspection of British schools overseas</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c92" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c92">
                           <label class="govuk-label govuk-checkboxes__label" for="c92">School performance measures</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c93" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c93">
                           <label class="govuk-label govuk-checkboxes__label" for="c93">Inspection of independent schools</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c94" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c94">
                           <label class="govuk-label govuk-checkboxes__label" for="c94">Pupil performance in schools</label>
                         </div>
                       </li>
@@ -626,43 +626,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c95" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c95">
                       <label class="govuk-label govuk-checkboxes__label" for="c95">Inspection and performance of further education providers</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c96" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c96">
                           <label class="govuk-label govuk-checkboxes__label" for="c96">Inspection of further education and skills providers</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c97" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c97">
                           <label class="govuk-label govuk-checkboxes__label" for="c97">Performance data and Ofsted reports of further education providers</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c98" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c98">
                           <label class="govuk-label govuk-checkboxes__label" for="c98">Further education provider performance measures</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c99" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c99">
                           <label class="govuk-label govuk-checkboxes__label" for="c99">Student performance in further education</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c100" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c100">
                           <label class="govuk-label govuk-checkboxes__label" for="c100">Further education intervention notices and reports</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c101" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c101">
                           <label class="govuk-label govuk-checkboxes__label" for="c101">Inspection of residential provision in further education colleges</label>
                         </div>
                       </li>
@@ -672,37 +672,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c102" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c102">
                   <label class="govuk-label govuk-checkboxes__label" for="c102">Education of disadvantaged children</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c103" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c103">
                   <label class="govuk-label govuk-checkboxes__label" for="c103">Starting and attending school</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c104" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c104">
                       <label class="govuk-label govuk-checkboxes__label" for="c104">Sending a child to school</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c105" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c105">
                       <label class="govuk-label govuk-checkboxes__label" for="c105">Help with school costs</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c106" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c106">
                       <label class="govuk-label govuk-checkboxes__label" for="c106">Dealing with problems at school</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c107" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c107">
                       <label class="govuk-label govuk-checkboxes__label" for="c107">Home schooling</label>
                     </div>
                   </li>
@@ -710,85 +710,85 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c108" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c108">
                   <label class="govuk-label govuk-checkboxes__label" for="c108">Running and managing a school</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c109" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c109">
                       <label class="govuk-label govuk-checkboxes__label" for="c109">School-to-school support</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c110" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c110">
                       <label class="govuk-label govuk-checkboxes__label" for="c110">Data collection and censuses for schools</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c111" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c111">
                           <label class="govuk-label govuk-checkboxes__label" for="c111">School censuses and school-level annual school censuses (SLASC)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c112" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c112">
                           <label class="govuk-label govuk-checkboxes__label" for="c112">School preference and admission appeals data collection</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c113" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c113">
                           <label class="govuk-label govuk-checkboxes__label" for="c113">Key stage 1 and 2 assessments data collection</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c114" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c114">
                           <label class="govuk-label govuk-checkboxes__label" for="c114">Parental responsibility measures attendance censuses</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c115" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c115">
                           <label class="govuk-label govuk-checkboxes__label" for="c115">School capacity surveys</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c116" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c116">
                           <label class="govuk-label govuk-checkboxes__label" for="c116">Alternative provision censuses</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c117" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c117">
                           <label class="govuk-label govuk-checkboxes__label" for="c117">Special educational needs surveys</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c118" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c118">
                           <label class="govuk-label govuk-checkboxes__label" for="c118">Phonics screening checks</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c119" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c119">
                           <label class="govuk-label govuk-checkboxes__label" for="c119">General hospital school censuses</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c120" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c120">
                           <label class="govuk-label govuk-checkboxes__label" for="c120">School exclusion reviews</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c121" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c121">
                           <label class="govuk-label govuk-checkboxes__label" for="c121">School workforce censuses</label>
                         </div>
                       </li>
@@ -796,25 +796,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c122" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c122">
                       <label class="govuk-label govuk-checkboxes__label" for="c122">School buildings and land</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c123" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c123">
                           <label class="govuk-label govuk-checkboxes__label" for="c123">School places</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c124" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c124">
                           <label class="govuk-label govuk-checkboxes__label" for="c124">School buildings and land transactions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c125" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c125">
                           <label class="govuk-label govuk-checkboxes__label" for="c125">School buildings and land guidelines</label>
                         </div>
                       </li>
@@ -822,43 +822,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c126" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c126">
                       <label class="govuk-label govuk-checkboxes__label" for="c126">School planning</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c127" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c127">
                       <label class="govuk-label govuk-checkboxes__label" for="c127">School governance</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c128" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c128">
                       <label class="govuk-label govuk-checkboxes__label" for="c128">School food, accommodation, transport and uniform</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c129" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c129">
                       <label class="govuk-label govuk-checkboxes__label" for="c129">Setting up or changing the status of a school</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c130" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c130">
                           <label class="govuk-label govuk-checkboxes__label" for="c130">Set up or convert to an academy</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c131" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c131">
                           <label class="govuk-label govuk-checkboxes__label" for="c131">Set up and develop a multi-academy trust (MAT)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c132" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c132">
                           <label class="govuk-label govuk-checkboxes__label" for="c132">Set up a free school</label>
                         </div>
                       </li>
@@ -866,31 +866,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c133" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c133">
                       <label class="govuk-label govuk-checkboxes__label" for="c133">School complaints and whistleblowing</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c134" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c134">
                       <label class="govuk-label govuk-checkboxes__label" for="c134">School trips and extracurricular activity</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c135" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c135">
                       <label class="govuk-label govuk-checkboxes__label" for="c135">School admissions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c136" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c136">
                       <label class="govuk-label govuk-checkboxes__label" for="c136">Careers guidance in schools</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c137" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c137">
                       <label class="govuk-label govuk-checkboxes__label" for="c137">Recruiting and managing non-teaching school staff</label>
                     </div>
                   </li>
@@ -898,31 +898,31 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c138" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c138">
                   <label class="govuk-label govuk-checkboxes__label" for="c138">School and academy financial management and assurance</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c139" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c139">
                       <label class="govuk-label govuk-checkboxes__label" for="c139">Financial management, reporting and assurances for 16 to 19 year olds funding</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c140" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c140">
                       <label class="govuk-label govuk-checkboxes__label" for="c140">School procurement</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c141" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c141">
                       <label class="govuk-label govuk-checkboxes__label" for="c141">Academy and academy trust finance and reporting</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c142" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c142">
                       <label class="govuk-label govuk-checkboxes__label" for="c142">Local authority schools financial reporting and assurance</label>
                     </div>
                   </li>
@@ -930,25 +930,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c143" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c143">
                   <label class="govuk-label govuk-checkboxes__label" for="c143">Funding and finance for students</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c144" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c144">
                       <label class="govuk-label govuk-checkboxes__label" for="c144">Student grants, bursaries and scholarships</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c145" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c145">
                       <label class="govuk-label govuk-checkboxes__label" for="c145">Financial help for students who are parents or carers</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c146" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c146">
                       <label class="govuk-label govuk-checkboxes__label" for="c146">Student loans</label>
                     </div>
                   </li>
@@ -956,43 +956,43 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c147" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c147">
                   <label class="govuk-label govuk-checkboxes__label" for="c147">School curriculum</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c148" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c148">
                       <label class="govuk-label govuk-checkboxes__label" for="c148">Primary curriculum, key stage 2</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c149" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c149">
                           <label class="govuk-label govuk-checkboxes__label" for="c149">Programmes of study (key stage 2)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c150" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c150">
                           <label class="govuk-label govuk-checkboxes__label" for="c150">Science (key stage 2)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c151" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c151">
                           <label class="govuk-label govuk-checkboxes__label" for="c151">English (key stage 2)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c152" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c152">
                           <label class="govuk-label govuk-checkboxes__label" for="c152">Maths (key stage 2)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c153" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c153">
                           <label class="govuk-label govuk-checkboxes__label" for="c153">Tests and assessments (key stage 2)</label>
                         </div>
                       </li>
@@ -1000,37 +1000,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c154" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c154">
                       <label class="govuk-label govuk-checkboxes__label" for="c154">Spiritual, moral, social and cultural development</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c155" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c155">
                       <label class="govuk-label govuk-checkboxes__label" for="c155">Early years curriculum</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c156" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c156">
                       <label class="govuk-label govuk-checkboxes__label" for="c156">Secondary curriculum, key stage 3 and key stage 4 (GCSEs)</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c157" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c157">
                           <label class="govuk-label govuk-checkboxes__label" for="c157">GCSE changes and reforms</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c158" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c158">
                           <label class="govuk-label govuk-checkboxes__label" for="c158">Key stage 3 and 4 exam marking, qualifications and results</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c159" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c159">
                           <label class="govuk-label govuk-checkboxes__label" for="c159">GCSE subject content and requirements</label>
                         </div>
                       </li>
@@ -1038,37 +1038,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c160" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c160">
                       <label class="govuk-label govuk-checkboxes__label" for="c160">Primary curriculum, key stage 1</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c161" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c161">
                           <label class="govuk-label govuk-checkboxes__label" for="c161">Programmes of study (key stage 1)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c162" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c162">
                           <label class="govuk-label govuk-checkboxes__label" for="c162">Science (key stage 1)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c163" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c163">
                           <label class="govuk-label govuk-checkboxes__label" for="c163">Maths (key stage 1)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c164" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c164">
                           <label class="govuk-label govuk-checkboxes__label" for="c164">Tests and assessments (key stage 1)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c165" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c165">
                           <label class="govuk-label govuk-checkboxes__label" for="c165">Phonics</label>
                         </div>
                       </li>
@@ -1076,37 +1076,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c166" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c166">
                       <label class="govuk-label govuk-checkboxes__label" for="c166">Exam regulation and administration</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c167" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c167">
                       <label class="govuk-label govuk-checkboxes__label" for="c167">Personal, social, health and economic education</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c168" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c168">
                       <label class="govuk-label govuk-checkboxes__label" for="c168">Key stage 5 (AS and A Levels)</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c169" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c169">
                           <label class="govuk-label govuk-checkboxes__label" for="c169">AS and A level subject content and requirements</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c170" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c170">
                           <label class="govuk-label govuk-checkboxes__label" for="c170">AS and A level changes and reforms</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c171" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c171">
                           <label class="govuk-label govuk-checkboxes__label" for="c171">Key stage 5 exam marking, qualifications and results</label>
                         </div>
                       </li>
@@ -1116,25 +1116,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c172" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c172">
                   <label class="govuk-label govuk-checkboxes__label" for="c172">Special educational needs and disability (SEND) and high needs</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c173" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c173">
                       <label class="govuk-label govuk-checkboxes__label" for="c173">Funding for special educational needs and disability (SEND)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c174" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c174">
                       <label class="govuk-label govuk-checkboxes__label" for="c174">Support for special educational needs and disability (SEND)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c175" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c175">
                       <label class="govuk-label govuk-checkboxes__label" for="c175">Funding for high needs</label>
                     </div>
                   </li>
@@ -1142,49 +1142,49 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c176" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c176">
                   <label class="govuk-label govuk-checkboxes__label" for="c176">School and academy funding</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c177" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c177">
                       <label class="govuk-label govuk-checkboxes__label" for="c177">Funding for different types of schools and settings</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c178" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c178">
                           <label class="govuk-label govuk-checkboxes__label" for="c178">Special schools funding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c179" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c179">
                           <label class="govuk-label govuk-checkboxes__label" for="c179">Alternative provision funding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c180" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c180">
                           <label class="govuk-label govuk-checkboxes__label" for="c180">Local authority schools funding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c181" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c181">
                           <label class="govuk-label govuk-checkboxes__label" for="c181">Funding for 16 to 19 year olds in schools</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c182" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c182">
                           <label class="govuk-label govuk-checkboxes__label" for="c182">Academy funding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c183" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c183">
                           <label class="govuk-label govuk-checkboxes__label" for="c183">Early years funding</label>
                         </div>
                       </li>
@@ -1192,43 +1192,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c184" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c184">
                       <label class="govuk-label govuk-checkboxes__label" for="c184">Pupil premium and other school premiums</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c185" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c185">
                       <label class="govuk-label govuk-checkboxes__label" for="c185">Free school meals (FSM) funding</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c186" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c186">
                       <label class="govuk-label govuk-checkboxes__label" for="c186">Funding for school buildings and land</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c187" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c187">
                       <label class="govuk-label govuk-checkboxes__label" for="c187">Schools forums</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c188" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c188">
                       <label class="govuk-label govuk-checkboxes__label" for="c188">Initial Teacher Training funding</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c189" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c189">
                           <label class="govuk-label govuk-checkboxes__label" for="c189">School Direct funding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c190" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c190">
                           <label class="govuk-label govuk-checkboxes__label" for="c190">Subject Knowledge Enhancement (SKE) funding</label>
                         </div>
                       </li>
@@ -1236,7 +1236,7 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c191" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c191">
                       <label class="govuk-label govuk-checkboxes__label" for="c191">Funding for school places</label>
                     </div>
                   </li>
@@ -1246,31 +1246,31 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c192" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c192">
               <label class="govuk-label govuk-checkboxes__label" for="c192">Parenting, childcare and children's services</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c193" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c193">
                   <label class="govuk-label govuk-checkboxes__label" for="c193">Divorce, separation and legal issues</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c194" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c194">
                       <label class="govuk-label govuk-checkboxes__label" for="c194">Disagreements about parentage</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c195" tabindex="-1" checked>
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c195" checked>
                       <label class="govuk-label govuk-checkboxes__label" for="c195">Child maintenance</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c196" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c196">
                       <label class="govuk-label govuk-checkboxes__label" for="c196">Child custody</label>
                     </div>
                   </li>
@@ -1278,55 +1278,55 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c197" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c197">
                   <label class="govuk-label govuk-checkboxes__label" for="c197">Childcare and early years</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c198" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c198">
                       <label class="govuk-label govuk-checkboxes__label" for="c198">Local authorities and early years</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c199" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c199">
                       <label class="govuk-label govuk-checkboxes__label" for="c199">Providing childcare</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c200" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c200">
                           <label class="govuk-label govuk-checkboxes__label" for="c200">Recruiting and managing early years staff</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c201" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c201">
                           <label class="govuk-label govuk-checkboxes__label" for="c201">Performance and inspection of childcare providers</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c202" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c202">
                           <label class="govuk-label govuk-checkboxes__label" for="c202">Funding and finance for childcare providers</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c203" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c203">
                           <label class="govuk-label govuk-checkboxes__label" for="c203">Early years curriculum (0 to 5)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c204" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c204">
                           <label class="govuk-label govuk-checkboxes__label" for="c204">Children's centres, childminders, pre-schools and nurseries</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c205" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c205">
                           <label class="govuk-label govuk-checkboxes__label" for="c205">Becoming a childcare provider</label>
                         </div>
                       </li>
@@ -1334,25 +1334,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c206" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c206">
                       <label class="govuk-label govuk-checkboxes__label" for="c206">Finding childcare</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c207" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c207">
                       <label class="govuk-label govuk-checkboxes__label" for="c207">Data collection for early years and childcare</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c208" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c208">
                           <label class="govuk-label govuk-checkboxes__label" for="c208">Early years census</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c209" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c209">
                           <label class="govuk-label govuk-checkboxes__label" for="c209">Early years foundation stage profile return</label>
                         </div>
                       </li>
@@ -1362,49 +1362,49 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c210" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c210">
                   <label class="govuk-label govuk-checkboxes__label" for="c210">Financial help if you have children</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c211" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c211">
                       <label class="govuk-label govuk-checkboxes__label" for="c211">Child benefit</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c212" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c212">
                       <label class="govuk-label govuk-checkboxes__label" for="c212">Financial help if you have a disabled child</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c213" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c213">
                       <label class="govuk-label govuk-checkboxes__label" for="c213">Tax credits if you have children</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c214" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c214">
                       <label class="govuk-label govuk-checkboxes__label" for="c214">Savings accounts for children</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c215" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c215">
                       <label class="govuk-label govuk-checkboxes__label" for="c215">Financial support for childcare</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c216" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c216">
                       <label class="govuk-label govuk-checkboxes__label" for="c216">Financial help when having a baby</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c217" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c217">
                       <label class="govuk-label govuk-checkboxes__label" for="c217">Financial help if you're a student with children</label>
                     </div>
                   </li>
@@ -1412,37 +1412,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c218" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c218">
                   <label class="govuk-label govuk-checkboxes__label" for="c218">Adoption, fostering and surrogacy</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c219" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c219">
                       <label class="govuk-label govuk-checkboxes__label" for="c219">Intercountry adoption</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c220" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c220">
                       <label class="govuk-label govuk-checkboxes__label" for="c220">Adoption</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c221" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c221">
                       <label class="govuk-label govuk-checkboxes__label" for="c221">Surrogacy</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c222" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c222">
                       <label class="govuk-label govuk-checkboxes__label" for="c222">Special guardianship</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c223" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c223">
                       <label class="govuk-label govuk-checkboxes__label" for="c223">Fostering</label>
                     </div>
                   </li>
@@ -1450,37 +1450,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c224" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c224">
                   <label class="govuk-label govuk-checkboxes__label" for="c224">Children's health and welfare</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c225" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c225">
                       <label class="govuk-label govuk-checkboxes__label" for="c225">Support for children with special educational needs and disabilities (SEND)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c226" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c226">
                       <label class="govuk-label govuk-checkboxes__label" for="c226">Mental health of children and young people</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c227" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c227">
                       <label class="govuk-label govuk-checkboxes__label" for="c227">Help for children with a long-term illness or disability</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c228" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c228">
                       <label class="govuk-label govuk-checkboxes__label" for="c228">Children's rights</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c229" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c229">
                       <label class="govuk-label govuk-checkboxes__label" for="c229">Child poverty</label>
                     </div>
                   </li>
@@ -1488,25 +1488,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c230" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c230">
                   <label class="govuk-label govuk-checkboxes__label" for="c230">Youth employment and social issues</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c231" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c231">
                   <label class="govuk-label govuk-checkboxes__label" for="c231">Pregnancy and birth</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c232" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c232">
                       <label class="govuk-label govuk-checkboxes__label" for="c232">Working and time off when you're having a baby</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c233" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c233">
                       <label class="govuk-label govuk-checkboxes__label" for="c233">Register the birth of a child</label>
                     </div>
                   </li>
@@ -1514,49 +1514,49 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c234" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c234">
                   <label class="govuk-label govuk-checkboxes__label" for="c234">Safeguarding and social care for children</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c235" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c235">
                       <label class="govuk-label govuk-checkboxes__label" for="c235">Child and family social work</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c236" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c236">
                       <label class="govuk-label govuk-checkboxes__label" for="c236">Safeguarding and child protection</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c237" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c237">
                           <label class="govuk-label govuk-checkboxes__label" for="c237">Data collection for safeguarding and child protection</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c238" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c238">
                           <label class="govuk-label govuk-checkboxes__label" for="c238">Preventing neglect, abuse and exploitation</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c239" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c239">
                           <label class="govuk-label govuk-checkboxes__label" for="c239">Serious case reviews</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c240" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c240">
                           <label class="govuk-label govuk-checkboxes__label" for="c240">Refugee, runaway and homeless children</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c241" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c241">
                           <label class="govuk-label govuk-checkboxes__label" for="c241">Child abduction and cross-border child protection</label>
                         </div>
                       </li>
@@ -1564,31 +1564,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c242" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c242">
                       <label class="govuk-label govuk-checkboxes__label" for="c242">Looked-after children and children in care</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c243" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c243">
                           <label class="govuk-label govuk-checkboxes__label" for="c243">Data collection for looked-after children</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c244" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c244">
                           <label class="govuk-label govuk-checkboxes__label" for="c244">Health, wellbeing and education of looked-after children</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c245" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c245">
                           <label class="govuk-label govuk-checkboxes__label" for="c245">Children's homes and other accommodation</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c246" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c246">
                           <label class="govuk-label govuk-checkboxes__label" for="c246">Children and young people leaving care</label>
                         </div>
                       </li>
@@ -1596,49 +1596,49 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c247" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c247">
                       <label class="govuk-label govuk-checkboxes__label" for="c247">Children's social care providers</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c248" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c248">
                           <label class="govuk-label govuk-checkboxes__label" for="c248">Becoming a children's social care provider</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c249" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c249">
                           <label class="govuk-label govuk-checkboxes__label" for="c249">Social care provider complaints</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c250" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c250">
                           <label class="govuk-label govuk-checkboxes__label" for="c250">Inspection of children's social care providers</label>
                         </div>
                         <ul class="govuk-list">
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c251" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c251">
                               <label class="govuk-label govuk-checkboxes__label" for="c251">Inspections of local authority children's services</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c252" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c252">
                               <label class="govuk-label govuk-checkboxes__label" for="c252">Inspections of fostering and adoption agencies</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c253" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c253">
                               <label class="govuk-label govuk-checkboxes__label" for="c253">Incidents, concerns and feedback about children's social care providers</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c254" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c254">
                               <label class="govuk-label govuk-checkboxes__label" for="c254">Children's homes and other residential care inspections</label>
                             </div>
                           </li>
@@ -1652,49 +1652,49 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c255" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c255">
               <label class="govuk-label govuk-checkboxes__label" for="c255">Corporate information</label>
             </div>
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c256" tabindex="-1" checked>
+              <input class="govuk-checkboxes__input" type="checkbox" id="c256" checked>
               <label class="govuk-label govuk-checkboxes__label" for="c256">Transport</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c257" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c257">
                   <label class="govuk-label govuk-checkboxes__label" for="c257">Transport modelling and appraisal</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c258" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c258">
                   <label class="govuk-label govuk-checkboxes__label" for="c258">Transport accessibility and mobility</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c259" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c259">
                       <label class="govuk-label govuk-checkboxes__label" for="c259">Help on public transport</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c260" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c260">
                       <label class="govuk-label govuk-checkboxes__label" for="c260">Blue badges</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c261" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c261">
                       <label class="govuk-label govuk-checkboxes__label" for="c261">Mobility scooters and wheelchairs</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c262" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c262">
                       <label class="govuk-label govuk-checkboxes__label" for="c262">Taxi and private hire accessibility</label>
                     </div>
                   </li>
@@ -1702,67 +1702,67 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c263" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c263">
                   <label class="govuk-label govuk-checkboxes__label" for="c263">Rail</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c264" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c264">
                       <label class="govuk-label govuk-checkboxes__label" for="c264">Rail accidents and serious incidents</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c265" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c265">
                       <label class="govuk-label govuk-checkboxes__label" for="c265">Rolling stock (passenger trains)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c266" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c266">
                       <label class="govuk-label govuk-checkboxes__label" for="c266">Community rail</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c267" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c267">
                       <label class="govuk-label govuk-checkboxes__label" for="c267">Rail network and the environment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c268" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c268">
                       <label class="govuk-label govuk-checkboxes__label" for="c268">HS2</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c269" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c269">
                           <label class="govuk-label govuk-checkboxes__label" for="c269">HS2 planning</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c270" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c270">
                           <label class="govuk-label govuk-checkboxes__label" for="c270">HS2 Phase One</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c271" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c271">
                           <label class="govuk-label govuk-checkboxes__label" for="c271">HS2 Phase Two</label>
                         </div>
                         <ul class="govuk-list">
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c272" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c272">
                               <label class="govuk-label govuk-checkboxes__label" for="c272">HS2 Phase 2b</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c273" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c273">
                               <label class="govuk-label govuk-checkboxes__label" for="c273">HS2 Phase 2a</label>
                             </div>
                           </li>
@@ -1770,73 +1770,73 @@
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c274" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c274">
                           <label class="govuk-label govuk-checkboxes__label" for="c274">HS2 costs</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c275" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c275">
                           <label class="govuk-label govuk-checkboxes__label" for="c275">HS2 additional provisions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c276" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c276">
                           <label class="govuk-label govuk-checkboxes__label" for="c276">HS2 design</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c277" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c277">
                           <label class="govuk-label govuk-checkboxes__label" for="c277">HS2 legislation</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c278" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c278">
                           <label class="govuk-label govuk-checkboxes__label" for="c278">HS2 stakeholder and community engagement</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c279" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c279">
                           <label class="govuk-label govuk-checkboxes__label" for="c279">HS2 stations</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c280" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c280">
                           <label class="govuk-label govuk-checkboxes__label" for="c280">HS2 supply chain</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c281" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c281">
                           <label class="govuk-label govuk-checkboxes__label" for="c281">HS2 construction and engineering</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c282" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c282">
                           <label class="govuk-label govuk-checkboxes__label" for="c282">HS2 property</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c283" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c283">
                           <label class="govuk-label govuk-checkboxes__label" for="c283">HS2 business case</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c284" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c284">
                           <label class="govuk-label govuk-checkboxes__label" for="c284">HS2 corporate</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c285" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c285">
                           <label class="govuk-label govuk-checkboxes__label" for="c285">HS2 and the environment</label>
                         </div>
                       </li>
@@ -1844,19 +1844,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c286" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c286">
                       <label class="govuk-label govuk-checkboxes__label" for="c286">Rail franchising</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c287" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c287">
                           <label class="govuk-label govuk-checkboxes__label" for="c287">Rail franchise public register</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c288" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c288">
                           <label class="govuk-label govuk-checkboxes__label" for="c288">Rail franchise procurement</label>
                         </div>
                       </li>
@@ -1864,55 +1864,55 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c289" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c289">
                       <label class="govuk-label govuk-checkboxes__label" for="c289">Rail passenger experience</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c290" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c290">
                       <label class="govuk-label govuk-checkboxes__label" for="c290">Rail stations</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c291" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c291">
                       <label class="govuk-label govuk-checkboxes__label" for="c291">Rail accessibility</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c292" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c292">
                       <label class="govuk-label govuk-checkboxes__label" for="c292">Rail safety and security</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c293" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c293">
                       <label class="govuk-label govuk-checkboxes__label" for="c293">Rail infrastructure</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c294" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c294">
                       <label class="govuk-label govuk-checkboxes__label" for="c294">Crossrail</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c295" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c295">
                       <label class="govuk-label govuk-checkboxes__label" for="c295">Rail ticketing and fares</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c296" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c296">
                       <label class="govuk-label govuk-checkboxes__label" for="c296">Rail interoperability</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c297" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c297">
                       <label class="govuk-label govuk-checkboxes__label" for="c297">Rail network</label>
                     </div>
                   </li>
@@ -1920,55 +1920,55 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c298" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c298">
                   <label class="govuk-label govuk-checkboxes__label" for="c298">Transport planning</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c299" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c299">
                   <label class="govuk-label govuk-checkboxes__label" for="c299">Transport security</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c300" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c300">
                   <label class="govuk-label govuk-checkboxes__label" for="c300">Corporate and operational information (transport)</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c301" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c301">
                   <label class="govuk-label govuk-checkboxes__label" for="c301">Driving and road transport</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c302" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c302">
                       <label class="govuk-label govuk-checkboxes__label" for="c302">Road traffic</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c303" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c303">
                       <label class="govuk-label govuk-checkboxes__label" for="c303">Road transport and the environment</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c304" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c304">
                           <label class="govuk-label govuk-checkboxes__label" for="c304">Road transport emissions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c305" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c305">
                           <label class="govuk-label govuk-checkboxes__label" for="c305">Low emission and electric vehicles</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c306" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c306">
                           <label class="govuk-label govuk-checkboxes__label" for="c306">Renewable fuels</label>
                         </div>
                       </li>
@@ -1976,43 +1976,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c307" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c307">
                       <label class="govuk-label govuk-checkboxes__label" for="c307">Transport businesses and vehicle operator licences</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c308" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c308">
                           <label class="govuk-label govuk-checkboxes__label" for="c308">Driver CPC training centres</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c309" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c309">
                           <label class="govuk-label govuk-checkboxes__label" for="c309">Employing drivers</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c310" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c310">
                           <label class="govuk-label govuk-checkboxes__label" for="c310">Vehicle operator licences</label>
                         </div>
                         <ul class="govuk-list">
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c311" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c311">
                               <label class="govuk-label govuk-checkboxes__label" for="c311">HGV and goods carriage vehicle licencing</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c312" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c312">
                               <label class="govuk-label govuk-checkboxes__label" for="c312">Public service vehicles licencing</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c313" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c313">
                               <label class="govuk-label govuk-checkboxes__label" for="c313">Taxi and private hire vehicle licencing</label>
                             </div>
                           </li>
@@ -2020,7 +2020,7 @@
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c314" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c314">
                           <label class="govuk-label govuk-checkboxes__label" for="c314">Fleet management</label>
                         </div>
                       </li>
@@ -2028,25 +2028,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c315" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c315">
                       <label class="govuk-label govuk-checkboxes__label" for="c315">Professional driving of lorries, buses and coaches</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c316" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c316">
                           <label class="govuk-label govuk-checkboxes__label" for="c316">Driver CPC training</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c317" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c317">
                           <label class="govuk-label govuk-checkboxes__label" for="c317">Tachographs</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c318" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c318">
                           <label class="govuk-label govuk-checkboxes__label" for="c318">EU and international driving rules</label>
                         </div>
                       </li>
@@ -2054,31 +2054,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c319" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c319">
                       <label class="govuk-label govuk-checkboxes__label" for="c319">Driving instruction and driving lessons</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c320" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c320">
                           <label class="govuk-label govuk-checkboxes__label" for="c320">Driving instructor registration and renewals</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c321" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c321">
                           <label class="govuk-label govuk-checkboxes__label" for="c321">Professional development for driving and motorcycle instructors</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c322" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c322">
                           <label class="govuk-label govuk-checkboxes__label" for="c322">Driving, motorcycle and LGV instructor qualification process</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c323" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c323">
                           <label class="govuk-label govuk-checkboxes__label" for="c323">Driving examination</label>
                         </div>
                       </li>
@@ -2086,61 +2086,61 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c324" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c324">
                       <label class="govuk-label govuk-checkboxes__label" for="c324">Road safety, driving rules and penalties</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c325" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c325">
                           <label class="govuk-label govuk-checkboxes__label" for="c325">Drink and drug driving</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c326" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c326">
                           <label class="govuk-label govuk-checkboxes__label" for="c326">Road accidents and serious accidents</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c327" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c327">
                           <label class="govuk-label govuk-checkboxes__label" for="c327">Drivers' hours</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c328" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c328">
                           <label class="govuk-label govuk-checkboxes__label" for="c328">Towing</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c329" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c329">
                           <label class="govuk-label govuk-checkboxes__label" for="c329">Penalty points, fines and driving bans</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c330" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c330">
                           <label class="govuk-label govuk-checkboxes__label" for="c330">Speeding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c331" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c331">
                           <label class="govuk-label govuk-checkboxes__label" for="c331">Seat belts</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c332" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c332">
                           <label class="govuk-label govuk-checkboxes__label" for="c332">Driving and mobile phones</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c333" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c333">
                           <label class="govuk-label govuk-checkboxes__label" for="c333">Driving and medical conditions</label>
                         </div>
                       </li>
@@ -2148,43 +2148,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c334" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c334">
                       <label class="govuk-label govuk-checkboxes__label" for="c334">Driving licences</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c335" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c335">
                           <label class="govuk-label govuk-checkboxes__label" for="c335">Driving licence applications and renewals</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c336" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c336">
                           <label class="govuk-label govuk-checkboxes__label" for="c336">Driving abroad</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c337" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c337">
                           <label class="govuk-label govuk-checkboxes__label" for="c337">Driving licence categories</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c338" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c338">
                           <label class="govuk-label govuk-checkboxes__label" for="c338">Foreign driving licences</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c339" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c339">
                           <label class="govuk-label govuk-checkboxes__label" for="c339">Driving licences and medical conditions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c340" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c340">
                           <label class="govuk-label govuk-checkboxes__label" for="c340">Personal driving licence information</label>
                         </div>
                       </li>
@@ -2192,37 +2192,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c341" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c341">
                       <label class="govuk-label govuk-checkboxes__label" for="c341">Driving and motorcycle tests</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c342" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c342">
                           <label class="govuk-label govuk-checkboxes__label" for="c342">Car driving tests</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c343" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c343">
                           <label class="govuk-label govuk-checkboxes__label" for="c343">Motorcycle and moped tests</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c344" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c344">
                           <label class="govuk-label govuk-checkboxes__label" for="c344">Lorry, bus, coach and specialist vehicle driving tests</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c345" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c345">
                           <label class="govuk-label govuk-checkboxes__label" for="c345">Theory tests</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c346" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c346">
                           <label class="govuk-label govuk-checkboxes__label" for="c346">Motorcycle training</label>
                         </div>
                       </li>
@@ -2230,61 +2230,61 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c347" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c347">
                       <label class="govuk-label govuk-checkboxes__label" for="c347">Vehicle ownership, approval and standards</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c348" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c348">
                           <label class="govuk-label govuk-checkboxes__label" for="c348">Buying, selling, registering and scrapping a vehicle</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c349" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c349">
                           <label class="govuk-label govuk-checkboxes__label" for="c349">PSV standards and checks</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c350" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c350">
                           <label class="govuk-label govuk-checkboxes__label" for="c350">Vehicle registration, log books and number plates</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c351" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c351">
                           <label class="govuk-label govuk-checkboxes__label" for="c351">HGV standards and checks</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c352" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c352">
                           <label class="govuk-label govuk-checkboxes__label" for="c352">Vehicle manufacturing and modification</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c353" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c353">
                           <label class="govuk-label govuk-checkboxes__label" for="c353">Vehicle recalls</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c354" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c354">
                           <label class="govuk-label govuk-checkboxes__label" for="c354">MOTs</label>
                         </div>
                         <ul class="govuk-list">
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c355" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c355">
                               <label class="govuk-label govuk-checkboxes__label" for="c355">Car, motorcycle and van MOT tests</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c356" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c356">
                               <label class="govuk-label govuk-checkboxes__label" for="c356">Lorry, bus and trailer MOT tests</label>
                             </div>
                           </li>
@@ -2292,25 +2292,25 @@
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c357" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c357">
                           <label class="govuk-label govuk-checkboxes__label" for="c357">Vehicle insurance</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c358" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c358">
                           <label class="govuk-label govuk-checkboxes__label" for="c358">Vehicle tax</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c359" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c359">
                           <label class="govuk-label govuk-checkboxes__label" for="c359">Vehicle import and export</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c360" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c360">
                           <label class="govuk-label govuk-checkboxes__label" for="c360">Driver and vehicle record</label>
                         </div>
                       </li>
@@ -2318,19 +2318,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c361" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c361">
                       <label class="govuk-label govuk-checkboxes__label" for="c361">Autonomous road vehicles</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c362" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c362">
                       <label class="govuk-label govuk-checkboxes__label" for="c362">Cycling and walking</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c363" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c363">
                       <label class="govuk-label govuk-checkboxes__label" for="c363">Vans and minibuses</label>
                     </div>
                   </li>
@@ -2338,31 +2338,31 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c364" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c364">
                   <label class="govuk-label govuk-checkboxes__label" for="c364">Freight and cargo</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c365" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c365">
                       <label class="govuk-label govuk-checkboxes__label" for="c365">Vessel cargo</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c366" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c366">
                       <label class="govuk-label govuk-checkboxes__label" for="c366">Transporting dangerous goods</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c367" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c367">
                           <label class="govuk-label govuk-checkboxes__label" for="c367">Safe transport of dangerous goods by sea</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c368" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c368">
                           <label class="govuk-label govuk-checkboxes__label" for="c368">Safe transport of dangerous goods by road and rail</label>
                         </div>
                       </li>
@@ -2370,13 +2370,13 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c369" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c369">
                       <label class="govuk-label govuk-checkboxes__label" for="c369">Rail freight and cargo</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c370" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c370">
                       <label class="govuk-label govuk-checkboxes__label" for="c370">Road freight</label>
                     </div>
                   </li>
@@ -2384,49 +2384,49 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c371" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c371">
                   <label class="govuk-label govuk-checkboxes__label" for="c371">Road infrastructure</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c372" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c372">
                       <label class="govuk-label govuk-checkboxes__label" for="c372">Road tolls and charges</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c373" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c373">
                       <label class="govuk-label govuk-checkboxes__label" for="c373">Road improvement and investment</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c374" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c374">
                           <label class="govuk-label govuk-checkboxes__label" for="c374">Road resurfacing</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c375" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c375">
                           <label class="govuk-label govuk-checkboxes__label" for="c375">Making roads safer</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c376" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c376">
                           <label class="govuk-label govuk-checkboxes__label" for="c376">Motorways</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c377" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c377">
                           <label class="govuk-label govuk-checkboxes__label" for="c377">Local roads</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c378" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c378">
                           <label class="govuk-label govuk-checkboxes__label" for="c378">Major roads</label>
                         </div>
                       </li>
@@ -2434,37 +2434,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c379" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c379">
                       <label class="govuk-label govuk-checkboxes__label" for="c379">Road works and street works</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c380" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c380">
                           <label class="govuk-label govuk-checkboxes__label" for="c380">Property affected by roadworks and street works</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c381" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c381">
                           <label class="govuk-label govuk-checkboxes__label" for="c381">Overnight works</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c382" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c382">
                           <label class="govuk-label govuk-checkboxes__label" for="c382">Road closures</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c383" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c383">
                           <label class="govuk-label govuk-checkboxes__label" for="c383">Planned roadworks</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c384" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c384">
                           <label class="govuk-label govuk-checkboxes__label" for="c384">Weekend closures</label>
                         </div>
                       </li>
@@ -2472,49 +2472,49 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c385" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c385">
                       <label class="govuk-label govuk-checkboxes__label" for="c385">Speed limits and traffic cameras</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c386" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c386">
                       <label class="govuk-label govuk-checkboxes__label" for="c386">Traffic signs, signals and markings</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c387" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c387">
                       <label class="govuk-label govuk-checkboxes__label" for="c387">Parking</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c388" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c388">
                       <label class="govuk-label govuk-checkboxes__label" for="c388">Smart motorways</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c389" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c389">
                       <label class="govuk-label govuk-checkboxes__label" for="c389">Advice for drivers</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c390" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c390">
                       <label class="govuk-label govuk-checkboxes__label" for="c390">Roads and the environment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c391" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c391">
                       <label class="govuk-label govuk-checkboxes__label" for="c391">Animals on roads</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c392" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c392">
                       <label class="govuk-label govuk-checkboxes__label" for="c392">Road maintenance</label>
                     </div>
                   </li>
@@ -2522,43 +2522,43 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c393" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c393">
                   <label class="govuk-label govuk-checkboxes__label" for="c393">Careers in transport</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c394" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c394">
                   <label class="govuk-label govuk-checkboxes__label" for="c394">Maritime and shipping</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c395" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c395">
                       <label class="govuk-label govuk-checkboxes__label" for="c395">Maritime accidents and serious incidents</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c396" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c396">
                       <label class="govuk-label govuk-checkboxes__label" for="c396">Vessel registration and design</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c397" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c397">
                           <label class="govuk-label govuk-checkboxes__label" for="c397">Ship equipment</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c398" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c398">
                           <label class="govuk-label govuk-checkboxes__label" for="c398">Vessel registration</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c399" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c399">
                           <label class="govuk-label govuk-checkboxes__label" for="c399">Vessel design</label>
                         </div>
                       </li>
@@ -2566,25 +2566,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c400" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c400">
                       <label class="govuk-label govuk-checkboxes__label" for="c400">Ports, harbours and offshore installations</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c401" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c401">
                       <label class="govuk-label govuk-checkboxes__label" for="c401">Maritime safety</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c402" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c402">
                           <label class="govuk-label govuk-checkboxes__label" for="c402">Life saving appliances (LSA)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c403" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c403">
                           <label class="govuk-label govuk-checkboxes__label" for="c403">Safe and compliant operation of vessels</label>
                         </div>
                       </li>
@@ -2592,49 +2592,49 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c404" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c404">
                       <label class="govuk-label govuk-checkboxes__label" for="c404">Maritime and the environment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c405" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c405">
                       <label class="govuk-label govuk-checkboxes__label" for="c405">Maritime navigation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c406" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c406">
                       <label class="govuk-label govuk-checkboxes__label" for="c406">Coastguard search and rescue</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c407" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c407">
                       <label class="govuk-label govuk-checkboxes__label" for="c407">Wrecks</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c408" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c408">
                       <label class="govuk-label govuk-checkboxes__label" for="c408">Seafarer management, training and certification</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c409" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c409">
                           <label class="govuk-label govuk-checkboxes__label" for="c409">Ship crew health and safety</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c410" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c410">
                           <label class="govuk-label govuk-checkboxes__label" for="c410">Ship crew training and certification</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c411" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c411">
                           <label class="govuk-label govuk-checkboxes__label" for="c411">Employment of seafarers</label>
                         </div>
                       </li>
@@ -2642,43 +2642,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c412" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c412">
                       <label class="govuk-label govuk-checkboxes__label" for="c412">Maritime enforcement and prosecution</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c413" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c413">
                       <label class="govuk-label govuk-checkboxes__label" for="c413">Fishing</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c414" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c414">
                       <label class="govuk-label govuk-checkboxes__label" for="c414">Vessel surveys and inspection</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c415" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c415">
                       <label class="govuk-label govuk-checkboxes__label" for="c415">Maritime security</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c416" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c416">
                       <label class="govuk-label govuk-checkboxes__label" for="c416">Waterways (maritime)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c417" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c417">
                       <label class="govuk-label govuk-checkboxes__label" for="c417">Maritime passenger rights</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c418" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c418">
                       <label class="govuk-label govuk-checkboxes__label" for="c418">UK sea passengers</label>
                     </div>
                   </li>
@@ -2686,61 +2686,61 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c419" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c419">
                   <label class="govuk-label govuk-checkboxes__label" for="c419">Aviation</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c420" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c420">
                       <label class="govuk-label govuk-checkboxes__label" for="c420">Air accidents and serious incidents</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c421" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c421">
                       <label class="govuk-label govuk-checkboxes__label" for="c421">General aviation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c422" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c422">
                       <label class="govuk-label govuk-checkboxes__label" for="c422">Air navigation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c423" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c423">
                       <label class="govuk-label govuk-checkboxes__label" for="c423">Airport capacity and expansion</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c424" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c424">
                       <label class="govuk-label govuk-checkboxes__label" for="c424">Aviation safety and security</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c425" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c425">
                       <label class="govuk-label govuk-checkboxes__label" for="c425">Aviation and the environment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c426" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c426">
                       <label class="govuk-label govuk-checkboxes__label" for="c426">New aviation technology</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c427" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c427">
                           <label class="govuk-label govuk-checkboxes__label" for="c427">Spaceflight</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c428" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c428">
                           <label class="govuk-label govuk-checkboxes__label" for="c428">Drones</label>
                         </div>
                       </li>
@@ -2748,37 +2748,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c429" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c429">
                       <label class="govuk-label govuk-checkboxes__label" for="c429">Night flights</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c430" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c430">
                       <label class="govuk-label govuk-checkboxes__label" for="c430">Aviation passenger experience</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c431" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c431">
                       <label class="govuk-label govuk-checkboxes__label" for="c431">Surface access to airports</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c432" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c432">
                       <label class="govuk-label govuk-checkboxes__label" for="c432">Aviation and Europe</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c433" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c433">
                       <label class="govuk-label govuk-checkboxes__label" for="c433">Air routes</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c434" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c434">
                       <label class="govuk-label govuk-checkboxes__label" for="c434">Air passenger duty</label>
                     </div>
                   </li>
@@ -2786,61 +2786,61 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c435" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c435">
                   <label class="govuk-label govuk-checkboxes__label" for="c435">Local transport</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c436" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c436">
                       <label class="govuk-label govuk-checkboxes__label" for="c436">Tube</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c437" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c437">
                       <label class="govuk-label govuk-checkboxes__label" for="c437">Local transport funding</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c438" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c438">
                       <label class="govuk-label govuk-checkboxes__label" for="c438">Buses</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c439" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c439">
                           <label class="govuk-label govuk-checkboxes__label" for="c439">Bus services, routes and timetables</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c440" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c440">
                           <label class="govuk-label govuk-checkboxes__label" for="c440">Bus accessibility</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c441" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c441">
                           <label class="govuk-label govuk-checkboxes__label" for="c441">Bus passenger experience</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c442" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c442">
                           <label class="govuk-label govuk-checkboxes__label" for="c442">Improvements to buses</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c443" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c443">
                           <label class="govuk-label govuk-checkboxes__label" for="c443">Bus operators</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c444" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c444">
                           <label class="govuk-label govuk-checkboxes__label" for="c444">Buses and the environment</label>
                         </div>
                       </li>
@@ -2848,19 +2848,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c445" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c445">
                       <label class="govuk-label govuk-checkboxes__label" for="c445">Inland waterways</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c446" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c446">
                       <label class="govuk-label govuk-checkboxes__label" for="c446">Light rail and trams</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c447" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c447">
                       <label class="govuk-label govuk-checkboxes__label" for="c447">Travel passes and concessions</label>
                     </div>
                   </li>
@@ -2870,55 +2870,55 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c448" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c448">
               <label class="govuk-label govuk-checkboxes__label" for="c448">Environment</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c449" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c449">
                   <label class="govuk-label govuk-checkboxes__label" for="c449">Environmental permits</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c450" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c450">
                   <label class="govuk-label govuk-checkboxes__label" for="c450">Water industry</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c451" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c451">
                       <label class="govuk-label govuk-checkboxes__label" for="c451">Water and sewerage services</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c452" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c452">
                       <label class="govuk-label govuk-checkboxes__label" for="c452">Drought and water availability</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c453" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c453">
                       <label class="govuk-label govuk-checkboxes__label" for="c453">Water quality</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c454" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c454">
                       <label class="govuk-label govuk-checkboxes__label" for="c454">Impound (store) water</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c455" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c455">
                       <label class="govuk-label govuk-checkboxes__label" for="c455">Discharge water</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c456" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c456">
                       <label class="govuk-label govuk-checkboxes__label" for="c456">Abstract (take) water</label>
                     </div>
                   </li>
@@ -2926,67 +2926,67 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c457" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c457">
                   <label class="govuk-label govuk-checkboxes__label" for="c457">Climate change and energy</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c458" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c458">
                       <label class="govuk-label govuk-checkboxes__label" for="c458">Hydropower</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c459" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c459">
                       <label class="govuk-label govuk-checkboxes__label" for="c459">Climate change adaptation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c460" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c460">
                       <label class="govuk-label govuk-checkboxes__label" for="c460">Climate change international action</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c461" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c461">
                       <label class="govuk-label govuk-checkboxes__label" for="c461">Greenhouse gas emissions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c462" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c462">
                       <label class="govuk-label govuk-checkboxes__label" for="c462">Energy and climate change: evidence and analysis</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c463" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c463">
                       <label class="govuk-label govuk-checkboxes__label" for="c463">Low carbon technologies</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c464" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c464">
                       <label class="govuk-label govuk-checkboxes__label" for="c464">Energy security</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c465" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c465">
                       <label class="govuk-label govuk-checkboxes__label" for="c465">Energy infrastructure</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c466" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c466">
                       <label class="govuk-label govuk-checkboxes__label" for="c466">Energy efficiency</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c467" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c467">
                       <label class="govuk-label govuk-checkboxes__label" for="c467">Emissions and emissions trading</label>
                     </div>
                   </li>
@@ -2994,67 +2994,67 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c468" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c468">
                   <label class="govuk-label govuk-checkboxes__label" for="c468">Rural and countryside</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c469" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c469">
                       <label class="govuk-label govuk-checkboxes__label" for="c469">Rural development and land management</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c470" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c470">
                           <label class="govuk-label govuk-checkboxes__label" for="c470">Rural economy and community</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c471" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c471">
                           <label class="govuk-label govuk-checkboxes__label" for="c471">Economic growth in rural areas</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c472" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c472">
                           <label class="govuk-label govuk-checkboxes__label" for="c472">Contaminated land</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c473" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c473">
                           <label class="govuk-label govuk-checkboxes__label" for="c473">Weeds and invasive, non-native plants</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c474" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c474">
                           <label class="govuk-label govuk-checkboxes__label" for="c474">Pollution</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c475" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c475">
                           <label class="govuk-label govuk-checkboxes__label" for="c475">Protected sites</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c476" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c476">
                           <label class="govuk-label govuk-checkboxes__label" for="c476">Farming</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c477" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c477">
                           <label class="govuk-label govuk-checkboxes__label" for="c477">Hedgerows</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c478" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c478">
                           <label class="govuk-label govuk-checkboxes__label" for="c478">Commons and greens</label>
                         </div>
                       </li>
@@ -3062,25 +3062,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c479" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c479">
                       <label class="govuk-label govuk-checkboxes__label" for="c479">Forests and woodland</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c480" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c480">
                       <label class="govuk-label govuk-checkboxes__label" for="c480">Countryside</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c481" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c481">
                           <label class="govuk-label govuk-checkboxes__label" for="c481">Parks, trails and nature reserves</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c482" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c482">
                           <label class="govuk-label govuk-checkboxes__label" for="c482">Access to the countryside</label>
                         </div>
                       </li>
@@ -3088,7 +3088,7 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c483" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c483">
                       <label class="govuk-label govuk-checkboxes__label" for="c483">Boats and waterways</label>
                     </div>
                   </li>
@@ -3096,73 +3096,73 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c484" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c484">
                   <label class="govuk-label govuk-checkboxes__label" for="c484">Pollution and environmental quality</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c485" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c485">
                   <label class="govuk-label govuk-checkboxes__label" for="c485">River maintenance, flooding and coastal erosion</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c486" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c486">
                   <label class="govuk-label govuk-checkboxes__label" for="c486">Wildlife, animals, biodiversity and ecosystems</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c487" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c487">
                       <label class="govuk-label govuk-checkboxes__label" for="c487">Animal welfare</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c488" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c488">
                       <label class="govuk-label govuk-checkboxes__label" for="c488">Pets</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c489" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c489">
                       <label class="govuk-label govuk-checkboxes__label" for="c489">Wildlife and habitat conservation</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c490" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c490">
                           <label class="govuk-label govuk-checkboxes__label" for="c490">Plants</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c491" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c491">
                           <label class="govuk-label govuk-checkboxes__label" for="c491">Reptiles and amphibians</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c492" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c492">
                           <label class="govuk-label govuk-checkboxes__label" for="c492">Mammals</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c493" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c493">
                           <label class="govuk-label govuk-checkboxes__label" for="c493">Fish and shellfish</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c494" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c494">
                           <label class="govuk-label govuk-checkboxes__label" for="c494">Invertebrates</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c495" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c495">
                           <label class="govuk-label govuk-checkboxes__label" for="c495">Birds</label>
                         </div>
                       </li>
@@ -3170,25 +3170,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c496" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c496">
                       <label class="govuk-label govuk-checkboxes__label" for="c496">Protected sites and species</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c497" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c497">
                           <label class="govuk-label govuk-checkboxes__label" for="c497">Land species</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c498" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c498">
                           <label class="govuk-label govuk-checkboxes__label" for="c498">Land sites</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c499" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c499">
                           <label class="govuk-label govuk-checkboxes__label" for="c499">Marine sites and species</label>
                         </div>
                       </li>
@@ -3196,19 +3196,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c500" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c500">
                       <label class="govuk-label govuk-checkboxes__label" for="c500">Animal and plant health</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c501" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c501">
                       <label class="govuk-label govuk-checkboxes__label" for="c501">Wildlife and animal welfare</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c502" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c502">
                       <label class="govuk-label govuk-checkboxes__label" for="c502">Biodiversity and ecosystems</label>
                     </div>
                   </li>
@@ -3216,61 +3216,61 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c503" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c503">
                   <label class="govuk-label govuk-checkboxes__label" for="c503">Commercial fishing, fisheries and vessels</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c504" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c504">
                       <label class="govuk-label govuk-checkboxes__label" for="c504">Marine fisheries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c505" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c505">
                       <label class="govuk-label govuk-checkboxes__label" for="c505">Freshwater fisheries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c506" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c506">
                       <label class="govuk-label govuk-checkboxes__label" for="c506">Fisheries funding</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c507" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c507">
                       <label class="govuk-label govuk-checkboxes__label" for="c507">Fishing vessels</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c508" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c508">
                           <label class="govuk-label govuk-checkboxes__label" for="c508">Vessel licensing and lists</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c509" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c509">
                           <label class="govuk-label govuk-checkboxes__label" for="c509">Vessel monitoring systems</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c510" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c510">
                           <label class="govuk-label govuk-checkboxes__label" for="c510">Vessel surveys and inspections</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c511" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c511">
                           <label class="govuk-label govuk-checkboxes__label" for="c511">Vessel licensing</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c512" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c512">
                           <label class="govuk-label govuk-checkboxes__label" for="c512">Vessel and crew safety and certification</label>
                         </div>
                       </li>
@@ -3278,37 +3278,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c513" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c513">
                       <label class="govuk-label govuk-checkboxes__label" for="c513">Fishing regulations, monitoring and enforcement</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c514" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c514">
                           <label class="govuk-label govuk-checkboxes__label" for="c514">Fishing quota and catch limits</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c515" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c515">
                           <label class="govuk-label govuk-checkboxes__label" for="c515">Sales notes and electronic recording systems</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c516" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c516">
                           <label class="govuk-label govuk-checkboxes__label" for="c516">Fisheries statistics</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c517" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c517">
                           <label class="govuk-label govuk-checkboxes__label" for="c517">First sale marine fish</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c518" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c518">
                           <label class="govuk-label govuk-checkboxes__label" for="c518">Catch Quota Trials</label>
                         </div>
                       </li>
@@ -3318,37 +3318,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c519" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c519">
                   <label class="govuk-label govuk-checkboxes__label" for="c519">Oil, gas and coal</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c520" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c520">
                       <label class="govuk-label govuk-checkboxes__label" for="c520">Coal</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c521" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c521">
                           <label class="govuk-label govuk-checkboxes__label" for="c521">Property and development</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c522" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c522">
                           <label class="govuk-label govuk-checkboxes__label" for="c522">Mining reports and data</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c523" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c523">
                           <label class="govuk-label govuk-checkboxes__label" for="c523">Mining permits and licences</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c524" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c524">
                           <label class="govuk-label govuk-checkboxes__label" for="c524">Mine water management</label>
                         </div>
                       </li>
@@ -3356,37 +3356,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c525" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c525">
                       <label class="govuk-label govuk-checkboxes__label" for="c525">Chemicals</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c526" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c526">
                           <label class="govuk-label govuk-checkboxes__label" for="c526">Mercury</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c527" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c527">
                           <label class="govuk-label govuk-checkboxes__label" for="c527">F-gases and HCFCs</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c528" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c528">
                           <label class="govuk-label govuk-checkboxes__label" for="c528">Contaminated land</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c529" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c529">
                           <label class="govuk-label govuk-checkboxes__label" for="c529">Polychlorinated biphenyl (PCBs)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c530" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c530">
                           <label class="govuk-label govuk-checkboxes__label" for="c530">REACH regulations</label>
                         </div>
                       </li>
@@ -3394,37 +3394,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c531" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c531">
                       <label class="govuk-label govuk-checkboxes__label" for="c531">Oil spills</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c532" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c532">
                       <label class="govuk-label govuk-checkboxes__label" for="c532">Onshore oil and gas</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c533" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c533">
                       <label class="govuk-label govuk-checkboxes__label" for="c533">Oil and gas licensing</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c534" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c534">
                       <label class="govuk-label govuk-checkboxes__label" for="c534">Oil and gas finance and taxation</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c535" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c535">
                           <label class="govuk-label govuk-checkboxes__label" for="c535">Tax and profits</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c536" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c536">
                           <label class="govuk-label govuk-checkboxes__label" for="c536">Market values</label>
                         </div>
                       </li>
@@ -3432,25 +3432,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c537" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c537">
                       <label class="govuk-label govuk-checkboxes__label" for="c537">Infrastructure and decommissioning</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c538" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c538">
                       <label class="govuk-label govuk-checkboxes__label" for="c538">Fields and wells</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c539" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c539">
                       <label class="govuk-label govuk-checkboxes__label" for="c539">Exploration and production</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c540" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c540">
                       <label class="govuk-label govuk-checkboxes__label" for="c540">Carbon capture and storage</label>
                     </div>
                   </li>
@@ -3458,25 +3458,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c541" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c541">
                   <label class="govuk-label govuk-checkboxes__label" for="c541">Waste and recycling</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c542" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c542">
                       <label class="govuk-label govuk-checkboxes__label" for="c542">Radioactive and nuclear substances and waste</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c543" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c543">
                       <label class="govuk-label govuk-checkboxes__label" for="c543">Waste and environmental impact</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c544" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c544">
                       <label class="govuk-label govuk-checkboxes__label" for="c544">Waste management</label>
                     </div>
                   </li>
@@ -3484,67 +3484,67 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c545" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c545">
                   <label class="govuk-label govuk-checkboxes__label" for="c545">Food and farming</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c546" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c546">
                       <label class="govuk-label govuk-checkboxes__label" for="c546">Farming and food grants and payments</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c547" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c547">
                           <label class="govuk-label govuk-checkboxes__label" for="c547">State aid</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c548" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c548">
                           <label class="govuk-label govuk-checkboxes__label" for="c548">School milk scheme</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c549" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c549">
                           <label class="govuk-label govuk-checkboxes__label" for="c549">Rural grants and payments</label>
                         </div>
                         <ul class="govuk-list">
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c550" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c550">
                               <label class="govuk-label govuk-checkboxes__label" for="c550">Countryside stewardship</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c551" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c551">
                               <label class="govuk-label govuk-checkboxes__label" for="c551">Cross-compliance</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c552" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c552">
                               <label class="govuk-label govuk-checkboxes__label" for="c552">Common Agricultural Policy (CAP) reform</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c553" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c553">
                               <label class="govuk-label govuk-checkboxes__label" for="c553">Rural development</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c554" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c554">
                               <label class="govuk-label govuk-checkboxes__label" for="c554">Online applications and payments</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c555" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c555">
                               <label class="govuk-label govuk-checkboxes__label" for="c555">Basic Payment Scheme (BPS)</label>
                             </div>
                           </li>
@@ -3552,13 +3552,13 @@
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c556" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c556">
                           <label class="govuk-label govuk-checkboxes__label" for="c556">Private storage aid</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c557" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c557">
                           <label class="govuk-label govuk-checkboxes__label" for="c557">Intervention schemes</label>
                         </div>
                       </li>
@@ -3566,49 +3566,49 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c558" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c558">
                       <label class="govuk-label govuk-checkboxes__label" for="c558">Producing and distributing food</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c559" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c559">
                           <label class="govuk-label govuk-checkboxes__label" for="c559">Sugar</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c560" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c560">
                           <label class="govuk-label govuk-checkboxes__label" for="c560">Meat production</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c561" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c561">
                           <label class="govuk-label govuk-checkboxes__label" for="c561">Import, export and distribution of food</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c562" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c562">
                           <label class="govuk-label govuk-checkboxes__label" for="c562">Dairy and milk production</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c563" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c563">
                           <label class="govuk-label govuk-checkboxes__label" for="c563">Food labelling and safety</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c564" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c564">
                           <label class="govuk-label govuk-checkboxes__label" for="c564">Egg production and marketing</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c565" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c565">
                           <label class="govuk-label govuk-checkboxes__label" for="c565">Crops and horticulture</label>
                         </div>
                       </li>
@@ -3616,73 +3616,73 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c566" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c566">
                       <label class="govuk-label govuk-checkboxes__label" for="c566">Keeping farmed animals</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c567" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c567">
                           <label class="govuk-label govuk-checkboxes__label" for="c567">Bovine tuberculosis (bovine TB)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c568" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c568">
                           <label class="govuk-label govuk-checkboxes__label" for="c568">Cattle identification, registration and movements</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c569" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c569">
                           <label class="govuk-label govuk-checkboxes__label" for="c569">Reporting disease and disease outbreaks</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c570" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c570">
                           <label class="govuk-label govuk-checkboxes__label" for="c570">Veterinary medicines</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c571" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c571">
                           <label class="govuk-label govuk-checkboxes__label" for="c571">Sheep and goats identification, registration and movements</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c572" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c572">
                           <label class="govuk-label govuk-checkboxes__label" for="c572">Shows, fairs and markets</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c573" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c573">
                           <label class="govuk-label govuk-checkboxes__label" for="c573">Poultry registration</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c574" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c574">
                           <label class="govuk-label govuk-checkboxes__label" for="c574">Pig identification, registration and movements</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c575" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c575">
                           <label class="govuk-label govuk-checkboxes__label" for="c575">Import and export of farmed animals</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c576" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c576">
                           <label class="govuk-label govuk-checkboxes__label" for="c576">Deer farming</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c577" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c577">
                           <label class="govuk-label govuk-checkboxes__label" for="c577">Cattle deaths</label>
                         </div>
                       </li>
@@ -3690,13 +3690,13 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c578" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c578">
                       <label class="govuk-label govuk-checkboxes__label" for="c578">Common Agricultural Policy reform</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c579" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c579">
                       <label class="govuk-label govuk-checkboxes__label" for="c579">Food and farming industry</label>
                     </div>
                   </li>
@@ -3704,67 +3704,67 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c580" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c580">
                   <label class="govuk-label govuk-checkboxes__label" for="c580">Marine</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c581" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c581">
                       <label class="govuk-label govuk-checkboxes__label" for="c581">Hydrography</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c582" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c582">
                       <label class="govuk-label govuk-checkboxes__label" for="c582">Marine environment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c583" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c583">
                       <label class="govuk-label govuk-checkboxes__label" for="c583">Marine planning</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c584" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c584">
                       <label class="govuk-label govuk-checkboxes__label" for="c584">Marine licences</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c585" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c585">
                       <label class="govuk-label govuk-checkboxes__label" for="c585">Treasure and wrecks</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c586" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c586">
                       <label class="govuk-label govuk-checkboxes__label" for="c586">Species protection and marine conservation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c587" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c587">
                       <label class="govuk-label govuk-checkboxes__label" for="c587">Harbour orders</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c588" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c588">
                       <label class="govuk-label govuk-checkboxes__label" for="c588">Marine protection and wildlife</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c589" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c589">
                       <label class="govuk-label govuk-checkboxes__label" for="c589">Harbours</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c590" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c590">
                       <label class="govuk-label govuk-checkboxes__label" for="c590">Sea fishing</label>
                     </div>
                   </li>
@@ -3774,25 +3774,25 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c591" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c591">
               <label class="govuk-label govuk-checkboxes__label" for="c591">Welfare</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c592" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c592">
                   <label class="govuk-label govuk-checkboxes__label" for="c592">Child Benefit</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c593" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c593">
                       <label class="govuk-label govuk-checkboxes__label" for="c593">High Income Tax Charge</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c594" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c594">
                       <label class="govuk-label govuk-checkboxes__label" for="c594">Support for families</label>
                     </div>
                   </li>
@@ -3800,61 +3800,61 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c595" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c595">
                   <label class="govuk-label govuk-checkboxes__label" for="c595">Carers and disability benefits</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c596" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c596">
                   <label class="govuk-label govuk-checkboxes__label" for="c596">Child maintenance reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c597" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c597">
                   <label class="govuk-label govuk-checkboxes__label" for="c597">Death and benefits</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c598" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c598">
                   <label class="govuk-label govuk-checkboxes__label" for="c598">Benefits for families</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c599" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c599">
                   <label class="govuk-label govuk-checkboxes__label" for="c599">Heating and housing benefits</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c600" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c600">
                   <label class="govuk-label govuk-checkboxes__label" for="c600">Tax credits</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c601" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c601">
                   <label class="govuk-label govuk-checkboxes__label" for="c601">Benefits entitlement</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c602" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c602">
                   <label class="govuk-label govuk-checkboxes__label" for="c602">Jobseeker's Allowance and low income benefits</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c603" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c603">
                   <label class="govuk-label govuk-checkboxes__label" for="c603">Universal Credit</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c604" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c604">
                   <label class="govuk-label govuk-checkboxes__label" for="c604">Welfare reform</label>
                 </div>
               </li>
@@ -3862,67 +3862,67 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c605" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c605">
               <label class="govuk-label govuk-checkboxes__label" for="c605">Housing, local and community</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c606" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c606">
                   <label class="govuk-label govuk-checkboxes__label" for="c606">Land registration</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c607" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c607">
                       <label class="govuk-label govuk-checkboxes__label" for="c607">Land Registration Data</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c608" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c608">
                       <label class="govuk-label govuk-checkboxes__label" for="c608">Land registration searches, fees and forms</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c609" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c609">
                       <label class="govuk-label govuk-checkboxes__label" for="c609">Business and mortgage services</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c610" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c610">
                           <label class="govuk-label govuk-checkboxes__label" for="c610">Property portfolio management</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c611" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c611">
                           <label class="govuk-label govuk-checkboxes__label" for="c611">Risk management</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c612" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c612">
                           <label class="govuk-label govuk-checkboxes__label" for="c612">Spatial data</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c613" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c613">
                           <label class="govuk-label govuk-checkboxes__label" for="c613">Mortgage services</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c614" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c614">
                           <label class="govuk-label govuk-checkboxes__label" for="c614">Ownership verification</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c615" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c615">
                           <label class="govuk-label govuk-checkboxes__label" for="c615">Conveyancing services</label>
                         </div>
                       </li>
@@ -3932,97 +3932,97 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c616" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c616">
                   <label class="govuk-label govuk-checkboxes__label" for="c616">Housing</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c617" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c617">
                       <label class="govuk-label govuk-checkboxes__label" for="c617">Neighbours, noise and pests</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c618" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c618">
                       <label class="govuk-label govuk-checkboxes__label" for="c618">Housing funding programmes</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c619" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c619">
                       <label class="govuk-label govuk-checkboxes__label" for="c619">Housing regulation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c620" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c620">
                       <label class="govuk-label govuk-checkboxes__label" for="c620">Recycling, rubbish, streets and roads</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c621" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c621">
                       <label class="govuk-label govuk-checkboxes__label" for="c621">Tenancies and leases</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c622" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c622">
                       <label class="govuk-label govuk-checkboxes__label" for="c622">Freehold and leasehold property</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c623" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c623">
                       <label class="govuk-label govuk-checkboxes__label" for="c623">Homebuying</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c624" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c624">
                       <label class="govuk-label govuk-checkboxes__label" for="c624">Rented housing sector</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c625" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c625">
                       <label class="govuk-label govuk-checkboxes__label" for="c625">Housing for older and vulnerable people</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c626" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c626">
                       <label class="govuk-label govuk-checkboxes__label" for="c626">Repossessions, emergency housing and evictions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c627" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c627">
                       <label class="govuk-label govuk-checkboxes__label" for="c627">Planning permission and building regulations</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c628" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c628">
                       <label class="govuk-label govuk-checkboxes__label" for="c628">Owning and renting a property</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c629" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c629">
                       <label class="govuk-label govuk-checkboxes__label" for="c629">Being a landlord and renting out a room</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c630" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c630">
                       <label class="govuk-label govuk-checkboxes__label" for="c630">Council housing and housing association</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c631" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c631">
                       <label class="govuk-label govuk-checkboxes__label" for="c631">Safety and the environment in your community</label>
                     </div>
                   </li>
@@ -4030,73 +4030,73 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c632" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c632">
                   <label class="govuk-label govuk-checkboxes__label" for="c632">Planning and building</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c633" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c633">
                       <label class="govuk-label govuk-checkboxes__label" for="c633">Party walls</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c634" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c634">
                       <label class="govuk-label govuk-checkboxes__label" for="c634">Energy efficiency in buildings</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c635" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c635">
                       <label class="govuk-label govuk-checkboxes__label" for="c635">Landscape</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c636" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c636">
                       <label class="govuk-label govuk-checkboxes__label" for="c636">Environmental planning</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c637" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c637">
                       <label class="govuk-label govuk-checkboxes__label" for="c637">Housing design and sustainability</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c638" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c638">
                       <label class="govuk-label govuk-checkboxes__label" for="c638">Land and development opportunities</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c639" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c639">
                       <label class="govuk-label govuk-checkboxes__label" for="c639">Local Plans</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c640" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c640">
                       <label class="govuk-label govuk-checkboxes__label" for="c640">Building regulations</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c641" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c641">
                           <label class="govuk-label govuk-checkboxes__label" for="c641">European legislation</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c642" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c642">
                           <label class="govuk-label govuk-checkboxes__label" for="c642">Compliance</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c643" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c643">
                           <label class="govuk-label govuk-checkboxes__label" for="c643">Doing building work</label>
                         </div>
                       </li>
@@ -4104,13 +4104,13 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c644" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c644">
                       <label class="govuk-label govuk-checkboxes__label" for="c644">Planning permission and appeals</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c645" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c645">
                           <label class="govuk-label govuk-checkboxes__label" for="c645">Make an appeal</label>
                         </div>
                       </li>
@@ -4118,31 +4118,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c646" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c646">
                       <label class="govuk-label govuk-checkboxes__label" for="c646">High streets and town centres</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c647" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c647">
                       <label class="govuk-label govuk-checkboxes__label" for="c647">Planning reform</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c648" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c648">
                       <label class="govuk-label govuk-checkboxes__label" for="c648">Building regulation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c649" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c649">
                       <label class="govuk-label govuk-checkboxes__label" for="c649">House building</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c650" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c650">
                       <label class="govuk-label govuk-checkboxes__label" for="c650">Planning system</label>
                     </div>
                   </li>
@@ -4150,7 +4150,7 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c651" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c651">
                   <label class="govuk-label govuk-checkboxes__label" for="c651">Household energy</label>
                 </div>
               </li>
@@ -4158,55 +4158,55 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c652" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c652">
               <label class="govuk-label govuk-checkboxes__label" for="c652">Life circumstances</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c653" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c653">
                   <label class="govuk-label govuk-checkboxes__label" for="c653">Having a child, parenting and adoption</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c654" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c654">
                   <label class="govuk-label govuk-checkboxes__label" for="c654">Certificates, register offices, changes of name or gender</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c655" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c655">
                   <label class="govuk-label govuk-checkboxes__label" for="c655">Lasting power of attorney, being in care and your financial affairs</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c656" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c656">
                   <label class="govuk-label govuk-checkboxes__label" for="c656">Marriage, civil partnership and divorce</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c657" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c657">
                       <label class="govuk-label govuk-checkboxes__label" for="c657">Child maintenance</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c658" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c658">
                       <label class="govuk-label govuk-checkboxes__label" for="c658">Help and support if you have children</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c659" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c659">
                       <label class="govuk-label govuk-checkboxes__label" for="c659">Getting separated or divorced</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c660" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c660">
                       <label class="govuk-label govuk-checkboxes__label" for="c660">Getting married</label>
                     </div>
                   </li>
@@ -4214,13 +4214,13 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c661" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c661">
                   <label class="govuk-label govuk-checkboxes__label" for="c661">Death and bereavement</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c662" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c662">
                       <label class="govuk-label govuk-checkboxes__label" for="c662">Death registration disclosure</label>
                     </div>
                   </li>
@@ -4230,55 +4230,55 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c663" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c663">
               <label class="govuk-label govuk-checkboxes__label" for="c663">International</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c664" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c664">
                   <label class="govuk-label govuk-checkboxes__label" for="c664">Foreign affairs</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c665" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c665">
                       <label class="govuk-label govuk-checkboxes__label" for="c665">Afghanistan</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c666" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c666">
                       <label class="govuk-label govuk-checkboxes__label" for="c666">Conflict in fragile states</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c667" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c667">
                       <label class="govuk-label govuk-checkboxes__label" for="c667">UK Overseas Territories</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c668" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c668">
                       <label class="govuk-label govuk-checkboxes__label" for="c668">Iran's nuclear programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c669" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c669">
                       <label class="govuk-label govuk-checkboxes__label" for="c669">Piracy off the coast of Somalia</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c670" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c670">
                       <label class="govuk-label govuk-checkboxes__label" for="c670">Falkland Islanders' right to self-determination</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c671" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c671">
                       <label class="govuk-label govuk-checkboxes__label" for="c671">Peace and stability in the Middle East and North Africa</label>
                     </div>
                   </li>
@@ -4286,73 +4286,73 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c672" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c672">
                   <label class="govuk-label govuk-checkboxes__label" for="c672">International aid and development</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c673" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c673">
                       <label class="govuk-label govuk-checkboxes__label" for="c673">Women and girls in developing countries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c674" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c674">
                       <label class="govuk-label govuk-checkboxes__label" for="c674">Health in developing countries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c675" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c675">
                       <label class="govuk-label govuk-checkboxes__label" for="c675">Governance in developing countries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c676" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c676">
                       <label class="govuk-label govuk-checkboxes__label" for="c676">Overseas aid transparency</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c677" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c677">
                       <label class="govuk-label govuk-checkboxes__label" for="c677">Overseas aid effectiveness</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c678" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c678">
                       <label class="govuk-label govuk-checkboxes__label" for="c678">Climate change impact in developing countries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c679" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c679">
                       <label class="govuk-label govuk-checkboxes__label" for="c679">Economic growth in developing countries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c680" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c680">
                       <label class="govuk-label govuk-checkboxes__label" for="c680">Hunger and malnutrition in developing countries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c681" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c681">
                       <label class="govuk-label govuk-checkboxes__label" for="c681">Education in developing countries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c682" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c682">
                       <label class="govuk-label govuk-checkboxes__label" for="c682">Humanitarian emergencies</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c683" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c683">
                       <label class="govuk-label govuk-checkboxes__label" for="c683">Water and sanitation in developing countries</label>
                     </div>
                   </li>
@@ -4360,31 +4360,31 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c684" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c684">
                   <label class="govuk-label govuk-checkboxes__label" for="c684">Human rights internationally</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c685" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c685">
                   <label class="govuk-label govuk-checkboxes__label" for="c685">UK prosperity and security: Asia, Latin America and Africa</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c686" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c686">
                   <label class="govuk-label govuk-checkboxes__label" for="c686">Anti-corruption</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c687" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c687">
                   <label class="govuk-label govuk-checkboxes__label" for="c687">The Commonwealth</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c688" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c688">
                   <label class="govuk-label govuk-checkboxes__label" for="c688">Sexual violence in conflict</label>
                 </div>
               </li>
@@ -4392,25 +4392,25 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c689" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c689">
               <label class="govuk-label govuk-checkboxes__label" for="c689">Health and social care</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c690" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c690">
                   <label class="govuk-label govuk-checkboxes__label" for="c690">Social care</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c691" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c691">
                       <label class="govuk-label govuk-checkboxes__label" for="c691">Health and social care integration</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c692" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c692">
                       <label class="govuk-label govuk-checkboxes__label" for="c692">Research and innovation in health and social care</label>
                     </div>
                   </li>
@@ -4418,43 +4418,43 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c693" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c693">
                   <label class="govuk-label govuk-checkboxes__label" for="c693">End of life care</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c694" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c694">
                   <label class="govuk-label govuk-checkboxes__label" for="c694">Carers' health</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c695" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c695">
                   <label class="govuk-label govuk-checkboxes__label" for="c695">Disabled people</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c696" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c696">
                       <label class="govuk-label govuk-checkboxes__label" for="c696">Disability equipment and transport</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c697" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c697">
                       <label class="govuk-label govuk-checkboxes__label" for="c697">Disability rights</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c698" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c698">
                       <label class="govuk-label govuk-checkboxes__label" for="c698">Benefits and financial help</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c699" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c699">
                       <label class="govuk-label govuk-checkboxes__label" for="c699">Carers</label>
                     </div>
                   </li>
@@ -4462,61 +4462,61 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c700" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c700">
                   <label class="govuk-label govuk-checkboxes__label" for="c700">Health protection</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c701" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c701">
                       <label class="govuk-label govuk-checkboxes__label" for="c701">Radiation protection</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c702" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c702">
                       <label class="govuk-label govuk-checkboxes__label" for="c702">Health emergency planning</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c703" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c703">
                       <label class="govuk-label govuk-checkboxes__label" for="c703">Chemical and environmental hazards</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c704" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c704">
                       <label class="govuk-label govuk-checkboxes__label" for="c704">Research, testing and standards</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c705" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c705">
                       <label class="govuk-label govuk-checkboxes__label" for="c705">Health surveillance and reporting programmes</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c706" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c706">
                       <label class="govuk-label govuk-checkboxes__label" for="c706">Laboratories and reference facilities</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c707" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c707">
                       <label class="govuk-label govuk-checkboxes__label" for="c707">Migrant health guide</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c708" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c708">
                           <label class="govuk-label govuk-checkboxes__label" for="c708">Assessing patients</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c709" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c709">
                           <label class="govuk-label govuk-checkboxes__label" for="c709">Migrants and the NHS</label>
                         </div>
                       </li>
@@ -4524,19 +4524,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c710" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c710">
                       <label class="govuk-label govuk-checkboxes__label" for="c710">Infectious diseases</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c711" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c711">
                       <label class="govuk-label govuk-checkboxes__label" for="c711">Immunisation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c712" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c712">
                       <label class="govuk-label govuk-checkboxes__label" for="c712">Emergency response</label>
                     </div>
                   </li>
@@ -4544,79 +4544,79 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c713" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c713">
                   <label class="govuk-label govuk-checkboxes__label" for="c713">Population screening programmes</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c714" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c714">
                       <label class="govuk-label govuk-checkboxes__label" for="c714">Quality assurance in population screening</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c715" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c715">
                       <label class="govuk-label govuk-checkboxes__label" for="c715">NHS newborn hearing screening programme (NHSP)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c716" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c716">
                       <label class="govuk-label govuk-checkboxes__label" for="c716">NHS sickle cell and thalassaemia (SCT) screening programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c717" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c717">
                       <label class="govuk-label govuk-checkboxes__label" for="c717">NHS newborn blood spot (NBS) screening programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c718" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c718">
                       <label class="govuk-label govuk-checkboxes__label" for="c718">NHS newborn and infant physical examination (NIPE) screening programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c719" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c719">
                       <label class="govuk-label govuk-checkboxes__label" for="c719">NHS infectious diseases in pregnancy screening (IDPS) programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c720" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c720">
                       <label class="govuk-label govuk-checkboxes__label" for="c720">NHS diabetic eye screening (DES) programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c721" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c721">
                       <label class="govuk-label govuk-checkboxes__label" for="c721">NHS cervical screening (CSP) programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c722" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c722">
                       <label class="govuk-label govuk-checkboxes__label" for="c722">NHS fetal anomaly screening programme (FASP)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c723" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c723">
                       <label class="govuk-label govuk-checkboxes__label" for="c723">NHS breast screening (BSP) programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c724" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c724">
                       <label class="govuk-label govuk-checkboxes__label" for="c724">NHS bowel cancer screening (BCSP) programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c725" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c725">
                       <label class="govuk-label govuk-checkboxes__label" for="c725">NHS abdominal aortic aneurysm (AAA) programme</label>
                     </div>
                   </li>
@@ -4624,37 +4624,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c726" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c726">
                   <label class="govuk-label govuk-checkboxes__label" for="c726">Medicines, medical devices and blood regulation and safety</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c727" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c727">
                       <label class="govuk-label govuk-checkboxes__label" for="c727">Clinical trials and investigations</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c728" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c728">
                       <label class="govuk-label govuk-checkboxes__label" for="c728">Medical devices regulation and safety</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c729" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c729">
                       <label class="govuk-label govuk-checkboxes__label" for="c729">Conferences and events</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c730" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c730">
                       <label class="govuk-label govuk-checkboxes__label" for="c730">Vigilance, safety alerts and guidance</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c731" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c731">
                           <label class="govuk-label govuk-checkboxes__label" for="c731">Alerts and recalls</label>
                         </div>
                       </li>
@@ -4662,31 +4662,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c732" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c732">
                       <label class="govuk-label govuk-checkboxes__label" for="c732">Herbal and homeopathic medicines</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c733" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c733">
                       <label class="govuk-label govuk-checkboxes__label" for="c733">Manufacturing, wholesaling, importing and exporting medicines</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c734" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c734">
                       <label class="govuk-label govuk-checkboxes__label" for="c734">Blood regulation and safety</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c735" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c735">
                       <label class="govuk-label govuk-checkboxes__label" for="c735">Marketing authorisations, variations and licensing guidance</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c736" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c736">
                       <label class="govuk-label govuk-checkboxes__label" for="c736">Good practice, inspections and enforcement</label>
                     </div>
                   </li>
@@ -4694,31 +4694,31 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c737" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c737">
                   <label class="govuk-label govuk-checkboxes__label" for="c737">National Health Service</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c738" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c738">
                       <label class="govuk-label govuk-checkboxes__label" for="c738">Children's health</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c739" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c739">
                       <label class="govuk-label govuk-checkboxes__label" for="c739">Compassionate care in the NHS</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c740" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c740">
                       <label class="govuk-label govuk-checkboxes__label" for="c740">NHS efficiency</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c741" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c741">
                       <label class="govuk-label govuk-checkboxes__label" for="c741">Patient safety</label>
                     </div>
                   </li>
@@ -4726,25 +4726,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c742" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c742">
                   <label class="govuk-label govuk-checkboxes__label" for="c742">Public health</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c743" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c743">
                       <label class="govuk-label govuk-checkboxes__label" for="c743">Abortion</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c744" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c744">
                       <label class="govuk-label govuk-checkboxes__label" for="c744">Mental health</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c745" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c745">
                           <label class="govuk-label govuk-checkboxes__label" for="c745">Mental health service reform</label>
                         </div>
                       </li>
@@ -4752,25 +4752,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c746" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c746">
                       <label class="govuk-label govuk-checkboxes__label" for="c746">Health conditions</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c747" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c747">
                           <label class="govuk-label govuk-checkboxes__label" for="c747">Long term health conditions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c748" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c748">
                           <label class="govuk-label govuk-checkboxes__label" for="c748">Dementia</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c749" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c749">
                           <label class="govuk-label govuk-checkboxes__label" for="c749">Autism</label>
                         </div>
                       </li>
@@ -4778,61 +4778,61 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c750" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c750">
                       <label class="govuk-label govuk-checkboxes__label" for="c750">Dentistry</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c751" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c751">
                       <label class="govuk-label govuk-checkboxes__label" for="c751">Ophthalmology</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c752" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c752">
                       <label class="govuk-label govuk-checkboxes__label" for="c752">Technology in health and social care</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c753" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c753">
                       <label class="govuk-label govuk-checkboxes__label" for="c753">Health improvement</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c754" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c754">
                           <label class="govuk-label govuk-checkboxes__label" for="c754">Obesity</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c755" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c755">
                           <label class="govuk-label govuk-checkboxes__label" for="c755">Healthy eating</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c756" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c756">
                           <label class="govuk-label govuk-checkboxes__label" for="c756">Cancer research and treatment</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c757" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c757">
                           <label class="govuk-label govuk-checkboxes__label" for="c757">Drug misuse and dependency</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c758" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c758">
                           <label class="govuk-label govuk-checkboxes__label" for="c758">Harmful drinking</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c759" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c759">
                           <label class="govuk-label govuk-checkboxes__label" for="c759">Smoking</label>
                         </div>
                       </li>
@@ -4844,61 +4844,61 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c760" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c760">
               <label class="govuk-label govuk-checkboxes__label" for="c760">Defence and armed forces</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c761" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c761">
                   <label class="govuk-label govuk-checkboxes__label" for="c761">UK nuclear deterrent</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c762" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c762">
                   <label class="govuk-label govuk-checkboxes__label" for="c762">Weapons proliferation</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c763" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c763">
                   <label class="govuk-label govuk-checkboxes__label" for="c763">Armed forces support for activities in the UK</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c764" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c764">
                   <label class="govuk-label govuk-checkboxes__label" for="c764">Armed forces</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c765" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c765">
                   <label class="govuk-label govuk-checkboxes__label" for="c765">Support services for veterans and their families</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c766" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c766">
                   <label class="govuk-label govuk-checkboxes__label" for="c766">Support services for military and defence personnel and their families</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c767" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c767">
                       <label class="govuk-label govuk-checkboxes__label" for="c767">Pensions and compensation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c768" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c768">
                       <label class="govuk-label govuk-checkboxes__label" for="c768">Housing and accommodation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c769" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c769">
                       <label class="govuk-label govuk-checkboxes__label" for="c769">British Forces Post Office</label>
                     </div>
                   </li>
@@ -4906,25 +4906,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c770" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c770">
                   <label class="govuk-label govuk-checkboxes__label" for="c770">Military awards and commemorations</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c771" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c771">
                       <label class="govuk-label govuk-checkboxes__label" for="c771">Veterans</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c772" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c772">
                       <label class="govuk-label govuk-checkboxes__label" for="c772">Medals</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c773" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c773">
                       <label class="govuk-label govuk-checkboxes__label" for="c773">Honours and awards</label>
                     </div>
                   </li>
@@ -4932,37 +4932,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c774" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c774">
                   <label class="govuk-label govuk-checkboxes__label" for="c774">Ministry of Defence estate</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c775" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c775">
                       <label class="govuk-label govuk-checkboxes__label" for="c775">Sale of land</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c776" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c776">
                       <label class="govuk-label govuk-checkboxes__label" for="c776">Public access</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c777" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c777">
                       <label class="govuk-label govuk-checkboxes__label" for="c777">Military crash sites</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c778" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c778">
                       <label class="govuk-label govuk-checkboxes__label" for="c778">Film locations</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c779" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c779">
                       <label class="govuk-label govuk-checkboxes__label" for="c779">Art collection</label>
                     </div>
                   </li>
@@ -4970,43 +4970,43 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c780" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c780">
                   <label class="govuk-label govuk-checkboxes__label" for="c780">Military recruitment, training and operations</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c781" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c781">
                   <label class="govuk-label govuk-checkboxes__label" for="c781">Military equipment, logistics and technology</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c782" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c782">
                   <label class="govuk-label govuk-checkboxes__label" for="c782">International defence commitments</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c783" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c783">
                   <label class="govuk-label govuk-checkboxes__label" for="c783">Stability in the Western Balkans</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c784" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c784">
                   <label class="govuk-label govuk-checkboxes__label" for="c784">Armed forces and Ministry of Defence reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c785" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c785">
                   <label class="govuk-label govuk-checkboxes__label" for="c785">Armed Forces Covenant</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c786" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c786">
                   <label class="govuk-label govuk-checkboxes__label" for="c786">Nuclear disarmament</label>
                 </div>
               </li>
@@ -5014,49 +5014,49 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c787" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c787">
               <label class="govuk-label govuk-checkboxes__label" for="c787">Crime, justice and law</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c788" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c788">
                   <label class="govuk-label govuk-checkboxes__label" for="c788">Young people and the law</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c789" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c789">
                   <label class="govuk-label govuk-checkboxes__label" for="c789">Statutory rights</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c790" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c790">
                   <label class="govuk-label govuk-checkboxes__label" for="c790">Your rights and the law</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c791" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c791">
                   <label class="govuk-label govuk-checkboxes__label" for="c791">Crime prevention</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c792" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c792">
                   <label class="govuk-label govuk-checkboxes__label" for="c792">Prisons and probation</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c793" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c793">
                       <label class="govuk-label govuk-checkboxes__label" for="c793">Prisons healthcare</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c794" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c794">
                       <label class="govuk-label govuk-checkboxes__label" for="c794">MAPPA</label>
                     </div>
                   </li>
@@ -5064,43 +5064,43 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c795" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c795">
                   <label class="govuk-label govuk-checkboxes__label" for="c795">Legal aid</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c796" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c796">
                       <label class="govuk-label govuk-checkboxes__label" for="c796">Civil and crime contracts</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c797" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c797">
                       <label class="govuk-label govuk-checkboxes__label" for="c797">Tenders</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c798" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c798">
                       <label class="govuk-label govuk-checkboxes__label" for="c798">Payments and processing</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c799" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c799">
                       <label class="govuk-label govuk-checkboxes__label" for="c799">Electronic working</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c800" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c800">
                       <label class="govuk-label govuk-checkboxes__label" for="c800">High cost and complex cases</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c801" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c801">
                       <label class="govuk-label govuk-checkboxes__label" for="c801">Crime</label>
                     </div>
                   </li>
@@ -5108,91 +5108,91 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c802" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c802">
                   <label class="govuk-label govuk-checkboxes__label" for="c802">Reporting crimes and getting compensation</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c803" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c803">
                   <label class="govuk-label govuk-checkboxes__label" for="c803">Courts, sentencing and tribunals</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c804" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c804">
                   <label class="govuk-label govuk-checkboxes__label" for="c804">Counter-terrorism</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c805" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c805">
                   <label class="govuk-label govuk-checkboxes__label" for="c805">Policing</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c806" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c806">
                   <label class="govuk-label govuk-checkboxes__label" for="c806">Knife, gun and gang crime</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c807" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c807">
                   <label class="govuk-label govuk-checkboxes__label" for="c807">Reoffending and rehabilitation</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c808" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c808">
                   <label class="govuk-label govuk-checkboxes__label" for="c808">Legal aid reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c809" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c809">
                   <label class="govuk-label govuk-checkboxes__label" for="c809">Attorney General guidance to the legal profession</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c810" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c810">
                   <label class="govuk-label govuk-checkboxes__label" for="c810">Forced marriage</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c811" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c811">
                   <label class="govuk-label govuk-checkboxes__label" for="c811">Domestic violence</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c812" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c812">
                   <label class="govuk-label govuk-checkboxes__label" for="c812">Law and practice</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c813" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c813">
                       <label class="govuk-label govuk-checkboxes__label" for="c813">Copyright</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c814" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c814">
                       <label class="govuk-label govuk-checkboxes__label" for="c814">Designs</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c815" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c815">
                       <label class="govuk-label govuk-checkboxes__label" for="c815">Patents</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c816" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c816">
                       <label class="govuk-label govuk-checkboxes__label" for="c816">Trade marks</label>
                     </div>
                   </li>
@@ -5200,67 +5200,67 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c817" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c817">
                   <label class="govuk-label govuk-checkboxes__label" for="c817">Family justice system</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c818" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c818">
                   <label class="govuk-label govuk-checkboxes__label" for="c818">Justice system transparency</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c819" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c819">
                   <label class="govuk-label govuk-checkboxes__label" for="c819">Violence against women and girls</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c820" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c820">
                   <label class="govuk-label govuk-checkboxes__label" for="c820">Criminal justice reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c821" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c821">
                   <label class="govuk-label govuk-checkboxes__label" for="c821">Civil justice reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c822" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c822">
                   <label class="govuk-label govuk-checkboxes__label" for="c822">Criminal record disclosure</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c823" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c823">
                   <label class="govuk-label govuk-checkboxes__label" for="c823">Victims of crime</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c824" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c824">
                   <label class="govuk-label govuk-checkboxes__label" for="c824">Sentencing reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c825" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c825">
                   <label class="govuk-label govuk-checkboxes__label" for="c825">Administrative justice reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c826" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c826">
                   <label class="govuk-label govuk-checkboxes__label" for="c826">Byelaws</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c827" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c827">
                   <label class="govuk-label govuk-checkboxes__label" for="c827">Data protection</label>
                 </div>
               </li>
@@ -5268,73 +5268,73 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c828" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c828">
               <label class="govuk-label govuk-checkboxes__label" for="c828">Regional and local government</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c829" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c829">
                   <label class="govuk-label govuk-checkboxes__label" for="c829">Devolution</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c830" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c830">
                   <label class="govuk-label govuk-checkboxes__label" for="c830">Local government</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c831" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c831">
                       <label class="govuk-label govuk-checkboxes__label" for="c831">Local government pensions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c832" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c832">
                       <label class="govuk-label govuk-checkboxes__label" for="c832">Local government finance and capital assets</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c833" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c833">
                       <label class="govuk-label govuk-checkboxes__label" for="c833">Local Housing Allowance</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c834" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c834">
                       <label class="govuk-label govuk-checkboxes__label" for="c834">Data collection and reporting</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c835" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c835">
                       <label class="govuk-label govuk-checkboxes__label" for="c835">Council Tax</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c836" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c836">
                           <label class="govuk-label govuk-checkboxes__label" for="c836">Council Tax reform</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c837" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c837">
                           <label class="govuk-label govuk-checkboxes__label" for="c837">Appeals and reductions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c838" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c838">
                           <label class="govuk-label govuk-checkboxes__label" for="c838">Renting</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c839" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c839">
                           <label class="govuk-label govuk-checkboxes__label" for="c839">Council Tax bands</label>
                         </div>
                       </li>
@@ -5342,31 +5342,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c840" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c840">
                       <label class="govuk-label govuk-checkboxes__label" for="c840">Councils and elections</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c841" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c841">
                       <label class="govuk-label govuk-checkboxes__label" for="c841">Business rates</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c842" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c842">
                           <label class="govuk-label govuk-checkboxes__label" for="c842">Relief, refunds and rebates</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c843" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c843">
                           <label class="govuk-label govuk-checkboxes__label" for="c843">Your rateable value</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c844" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c844">
                           <label class="govuk-label govuk-checkboxes__label" for="c844">Submit your rent or lease details</label>
                         </div>
                       </li>
@@ -5376,19 +5376,19 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c845" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c845">
                   <label class="govuk-label govuk-checkboxes__label" for="c845">Wales</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c846" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c846">
                       <label class="govuk-label govuk-checkboxes__label" for="c846">Economic growth in Wales</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c847" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c847">
                       <label class="govuk-label govuk-checkboxes__label" for="c847">Welsh devolution</label>
                     </div>
                   </li>
@@ -5396,37 +5396,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c848" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c848">
                   <label class="govuk-label govuk-checkboxes__label" for="c848">Local government spending</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c849" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c849">
                   <label class="govuk-label govuk-checkboxes__label" for="c849">Northern Ireland</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c850" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c850">
                       <label class="govuk-label govuk-checkboxes__label" for="c850">Northern Ireland security</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c851" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c851">
                       <label class="govuk-label govuk-checkboxes__label" for="c851">Northern Ireland economy</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c852" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c852">
                       <label class="govuk-label govuk-checkboxes__label" for="c852">Northern Ireland political stability</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c853" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c853">
                       <label class="govuk-label govuk-checkboxes__label" for="c853">Northern Ireland community relations</label>
                     </div>
                   </li>
@@ -5434,25 +5434,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c854" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c854">
                   <label class="govuk-label govuk-checkboxes__label" for="c854">Localism</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c855" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c855">
                   <label class="govuk-label govuk-checkboxes__label" for="c855">Scotland</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c856" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c856">
                       <label class="govuk-label govuk-checkboxes__label" for="c856">Scottish constitution</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c857" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c857">
                       <label class="govuk-label govuk-checkboxes__label" for="c857">Scottish devolution</label>
                     </div>
                   </li>
@@ -5460,7 +5460,7 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c858" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c858">
                   <label class="govuk-label govuk-checkboxes__label" for="c858">Local councils and services</label>
                 </div>
               </li>
@@ -5468,49 +5468,49 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c859" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c859">
               <label class="govuk-label govuk-checkboxes__label" for="c859">Society and culture</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c860" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c860">
                   <label class="govuk-label govuk-checkboxes__label" for="c860">Charities, volunteering and honours</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c861" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c861">
                   <label class="govuk-label govuk-checkboxes__label" for="c861">British citizenship</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c862" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c862">
                   <label class="govuk-label govuk-checkboxes__label" for="c862">Community and society</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c863" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c863">
                       <label class="govuk-label govuk-checkboxes__label" for="c863">Community integration</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c864" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c864">
                       <label class="govuk-label govuk-checkboxes__label" for="c864">National Lottery funding</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c865" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c865">
                       <label class="govuk-label govuk-checkboxes__label" for="c865">Social investment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c866" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c866">
                       <label class="govuk-label govuk-checkboxes__label" for="c866">Social action</label>
                     </div>
                   </li>
@@ -5518,25 +5518,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c867" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c867">
                   <label class="govuk-label govuk-checkboxes__label" for="c867">Arts and culture</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c868" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c868">
                       <label class="govuk-label govuk-checkboxes__label" for="c868">Museums and galleries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c869" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c869">
                       <label class="govuk-label govuk-checkboxes__label" for="c869">Library services</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c870" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c870">
                       <label class="govuk-label govuk-checkboxes__label" for="c870">Conservation of historic buildings and monuments</label>
                     </div>
                   </li>
@@ -5544,37 +5544,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c871" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c871">
                   <label class="govuk-label govuk-checkboxes__label" for="c871">Sports and leisure</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c872" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c872">
                       <label class="govuk-label govuk-checkboxes__label" for="c872">2012 Olympic and Paralympic legacy</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c873" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c873">
                       <label class="govuk-label govuk-checkboxes__label" for="c873">Recreation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c874" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c874">
                       <label class="govuk-label govuk-checkboxes__label" for="c874">Community amateur sports clubs (CASCs)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c875" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c875">
                       <label class="govuk-label govuk-checkboxes__label" for="c875">Elite sports performance</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c876" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c876">
                       <label class="govuk-label govuk-checkboxes__label" for="c876">Sports participation</label>
                     </div>
                   </li>
@@ -5582,31 +5582,31 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c877" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c877">
                   <label class="govuk-label govuk-checkboxes__label" for="c877">National events and ceremonies</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c878" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c878">
                   <label class="govuk-label govuk-checkboxes__label" for="c878">Equality, rights and citizenship</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c879" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c879">
                       <label class="govuk-label govuk-checkboxes__label" for="c879">Equality</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c880" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c880">
                       <label class="govuk-label govuk-checkboxes__label" for="c880">Poverty and social justice</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c881" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c881">
                       <label class="govuk-label govuk-checkboxes__label" for="c881">Social mobility</label>
                     </div>
                   </li>
@@ -5614,25 +5614,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c882" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c882">
                   <label class="govuk-label govuk-checkboxes__label" for="c882">Loneliness</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c883" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c883">
                   <label class="govuk-label govuk-checkboxes__label" for="c883">Tourism</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c884" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c884">
                   <label class="govuk-label govuk-checkboxes__label" for="c884">Digital inclusion and accessibility</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c885" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c885">
                   <label class="govuk-label govuk-checkboxes__label" for="c885">Young people</label>
                 </div>
               </li>
@@ -5640,43 +5640,43 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c886" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c886">
               <label class="govuk-label govuk-checkboxes__label" for="c886">Government</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c887" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c887">
                   <label class="govuk-label govuk-checkboxes__label" for="c887">Public sector land use</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c888" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c888">
                   <label class="govuk-label govuk-checkboxes__label" for="c888">Brexit</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c889" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c889">
                   <label class="govuk-label govuk-checkboxes__label" for="c889">National security</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c890" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c890">
                   <label class="govuk-label govuk-checkboxes__label" for="c890">Government efficiency, transparency and accountability</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c891" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c891">
                       <label class="govuk-label govuk-checkboxes__label" for="c891">Government spending</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c892" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c892">
                           <label class="govuk-label govuk-checkboxes__label" for="c892">Government funding programmes</label>
                         </div>
                       </li>
@@ -5684,13 +5684,13 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c893" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c893">
                       <label class="govuk-label govuk-checkboxes__label" for="c893">Major project management</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c894" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c894">
                       <label class="govuk-label govuk-checkboxes__label" for="c894">Deficit reduction</label>
                     </div>
                   </li>
@@ -5698,13 +5698,13 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c895" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c895">
                   <label class="govuk-label govuk-checkboxes__label" for="c895">Emergency preparation, response and recovery</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c896" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c896">
                       <label class="govuk-label govuk-checkboxes__label" for="c896">Fire prevention and rescue</label>
                     </div>
                   </li>
@@ -5712,67 +5712,67 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c897" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c897">
                   <label class="govuk-label govuk-checkboxes__label" for="c897">Public services</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c898" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c898">
                   <label class="govuk-label govuk-checkboxes__label" for="c898">Government technology and digital services</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c899" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c899">
                       <label class="govuk-label govuk-checkboxes__label" for="c899">GOV.UK services</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c900" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c900">
                           <label class="govuk-label govuk-checkboxes__label" for="c900">GOV.UK Pay</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c901" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c901">
                           <label class="govuk-label govuk-checkboxes__label" for="c901">GOV.UK Verify</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c902" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c902">
                           <label class="govuk-label govuk-checkboxes__label" for="c902">GOV.UK Platform as a Service (PaaS)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c903" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c903">
                           <label class="govuk-label govuk-checkboxes__label" for="c903">GOV.UK Proposition</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c904" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c904">
                           <label class="govuk-label govuk-checkboxes__label" for="c904">GOV.UK Notify</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c905" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c905">
                           <label class="govuk-label govuk-checkboxes__label" for="c905">GovWifi</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c906" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c906">
                           <label class="govuk-label govuk-checkboxes__label" for="c906">Performance platform</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c907" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c907">
                           <label class="govuk-label govuk-checkboxes__label" for="c907">GOV.UK Registers</label>
                         </div>
                       </li>
@@ -5780,19 +5780,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c908" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c908">
                       <label class="govuk-label govuk-checkboxes__label" for="c908">Networks and telecommunications</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c909" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c909">
                           <label class="govuk-label govuk-checkboxes__label" for="c909">Telecommunications</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c910" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c910">
                           <label class="govuk-label govuk-checkboxes__label" for="c910">Networking</label>
                         </div>
                       </li>
@@ -5800,19 +5800,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c911" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c911">
                       <label class="govuk-label govuk-checkboxes__label" for="c911">Open source and open standards</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c912" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c912">
                           <label class="govuk-label govuk-checkboxes__label" for="c912">Open standards</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c913" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c913">
                           <label class="govuk-label govuk-checkboxes__label" for="c913">Open source</label>
                         </div>
                       </li>
@@ -5820,55 +5820,55 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c914" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c914">
                       <label class="govuk-label govuk-checkboxes__label" for="c914">Digital security</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c915" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c915">
                           <label class="govuk-label govuk-checkboxes__label" for="c915">Cloud security</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c916" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c916">
                           <label class="govuk-label govuk-checkboxes__label" for="c916">Digital service security</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c917" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c917">
                           <label class="govuk-label govuk-checkboxes__label" for="c917">End user devices</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c918" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c918">
                           <label class="govuk-label govuk-checkboxes__label" for="c918">Identity assurance</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c919" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c919">
                           <label class="govuk-label govuk-checkboxes__label" for="c919">Passwords</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c920" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c920">
                           <label class="govuk-label govuk-checkboxes__label" for="c920">Phishing</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c921" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c921">
                           <label class="govuk-label govuk-checkboxes__label" for="c921">Email</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c922" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c922">
                           <label class="govuk-label govuk-checkboxes__label" for="c922">Risk management</label>
                         </div>
                       </li>
@@ -5876,19 +5876,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c923" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c923">
                       <label class="govuk-label govuk-checkboxes__label" for="c923">APIs and app development</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c924" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c924">
                           <label class="govuk-label govuk-checkboxes__label" for="c924">Application development</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c925" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c925">
                           <label class="govuk-label govuk-checkboxes__label" for="c925">APIs</label>
                         </div>
                       </li>
@@ -5896,25 +5896,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c926" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c926">
                       <label class="govuk-label govuk-checkboxes__label" for="c926">Design and build of government services</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c927" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c927">
                           <label class="govuk-label govuk-checkboxes__label" for="c927">Government content and publishing</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c928" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c928">
                           <label class="govuk-label govuk-checkboxes__label" for="c928">Design principles</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c929" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c929">
                           <label class="govuk-label govuk-checkboxes__label" for="c929">Digital Service Standard</label>
                         </div>
                       </li>
@@ -5922,19 +5922,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c930" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c930">
                       <label class="govuk-label govuk-checkboxes__label" for="c930">Data</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c931" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c931">
                           <label class="govuk-label govuk-checkboxes__label" for="c931">Data usage</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c932" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c932">
                           <label class="govuk-label govuk-checkboxes__label" for="c932">Data provisioning</label>
                         </div>
                       </li>
@@ -5942,25 +5942,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c933" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c933">
                       <label class="govuk-label govuk-checkboxes__label" for="c933">User research</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c934" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c934">
                       <label class="govuk-label govuk-checkboxes__label" for="c934">Public Service Network (PSN)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c935" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c935">
                       <label class="govuk-label govuk-checkboxes__label" for="c935">Managing government websites</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c936" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c936">
                           <label class="govuk-label govuk-checkboxes__label" for="c936">Hosting your service</label>
                         </div>
                       </li>
@@ -5968,37 +5968,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c937" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c937">
                       <label class="govuk-label govuk-checkboxes__label" for="c937">Digital transformation</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c938" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c938">
                           <label class="govuk-label govuk-checkboxes__label" for="c938">Green technology</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c939" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c939">
                           <label class="govuk-label govuk-checkboxes__label" for="c939">Legacy</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c940" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c940">
                           <label class="govuk-label govuk-checkboxes__label" for="c940">Smarter working</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c941" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c941">
                           <label class="govuk-label govuk-checkboxes__label" for="c941">Cloud strategy</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c942" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c942">
                           <label class="govuk-label govuk-checkboxes__label" for="c942">Job roles and talent acquisition</label>
                         </div>
                       </li>
@@ -6006,19 +6006,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c943" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c943">
                       <label class="govuk-label govuk-checkboxes__label" for="c943">Buying technology</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c944" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c944">
                           <label class="govuk-label govuk-checkboxes__label" for="c944">Digital outcomes and specialists framework</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c945" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c945">
                           <label class="govuk-label govuk-checkboxes__label" for="c945">Digital Marketplace</label>
                         </div>
                       </li>
@@ -6028,37 +6028,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c946" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c946">
                   <label class="govuk-label govuk-checkboxes__label" for="c946">Sustainable development</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c947" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c947">
                   <label class="govuk-label govuk-checkboxes__label" for="c947">Cyber security</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c948" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c948">
                   <label class="govuk-label govuk-checkboxes__label" for="c948">Europe</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c949" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c949">
                       <label class="govuk-label govuk-checkboxes__label" for="c949">European Union laws and regulation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c950" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c950">
                       <label class="govuk-label govuk-checkboxes__label" for="c950">European single market</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c951" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c951">
                       <label class="govuk-label govuk-checkboxes__label" for="c951">European funds</label>
                     </div>
                   </li>
@@ -6066,25 +6066,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c952" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c952">
                   <label class="govuk-label govuk-checkboxes__label" for="c952">Democracy</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c953" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c953">
                       <label class="govuk-label govuk-checkboxes__label" for="c953">Legislative process</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c954" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c954">
                       <label class="govuk-label govuk-checkboxes__label" for="c954">Constitutional affairs</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c955" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c955">
                       <label class="govuk-label govuk-checkboxes__label" for="c955">Voting</label>
                     </div>
                   </li>
@@ -6092,19 +6092,19 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c956" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c956">
                   <label class="govuk-label govuk-checkboxes__label" for="c956">Government reform</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c957" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c957">
                       <label class="govuk-label govuk-checkboxes__label" for="c957">Civil service reform</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c958" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c958">
                       <label class="govuk-label govuk-checkboxes__label" for="c958">Postal service reform</label>
                     </div>
                   </li>
@@ -6114,55 +6114,55 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c959" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c959">
               <label class="govuk-label govuk-checkboxes__label" for="c959">Work</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c960" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c960">
                   <label class="govuk-label govuk-checkboxes__label" for="c960">Secondments with government</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c961" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c961">
                   <label class="govuk-label govuk-checkboxes__label" for="c961">Government graduate schemes</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c962" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c962">
                   <label class="govuk-label govuk-checkboxes__label" for="c962">Self-employment</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c963" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c963">
                       <label class="govuk-label govuk-checkboxes__label" for="c963">Stopping or selling your business</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c964" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c964">
                       <label class="govuk-label govuk-checkboxes__label" for="c964">Paying HMRC</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c965" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c965">
                       <label class="govuk-label govuk-checkboxes__label" for="c965">Managing expenses</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c966" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c966">
                       <label class="govuk-label govuk-checkboxes__label" for="c966">Self Assessment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c967" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c967">
                       <label class="govuk-label govuk-checkboxes__label" for="c967">Tax and National Insurance</label>
                     </div>
                   </li>
@@ -6170,85 +6170,85 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c968" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c968">
                   <label class="govuk-label govuk-checkboxes__label" for="c968">Labour market reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c969" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c969">
                   <label class="govuk-label govuk-checkboxes__label" for="c969">Health and safety reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c970" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c970">
                   <label class="govuk-label govuk-checkboxes__label" for="c970">Work and disabled people</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c971" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c971">
                   <label class="govuk-label govuk-checkboxes__label" for="c971">Working, jobs and pensions</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c972" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c972">
                       <label class="govuk-label govuk-checkboxes__label" for="c972">Redundancies, dismissals and disciplinaries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c973" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c973">
                       <label class="govuk-label govuk-checkboxes__label" for="c973">Contracts and working hours</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c974" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c974">
                       <label class="govuk-label govuk-checkboxes__label" for="c974">Workplace bullying and harassment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c975" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c975">
                       <label class="govuk-label govuk-checkboxes__label" for="c975">Your rights at work and trade unions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c976" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c976">
                       <label class="govuk-label govuk-checkboxes__label" for="c976">Workplace and personal pensions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c977" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c977">
                       <label class="govuk-label govuk-checkboxes__label" for="c977">Holidays, time off, sick leave, maternity and paternity leave</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c978" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c978">
                       <label class="govuk-label govuk-checkboxes__label" for="c978">Your pay, tax and the National Minimum Wage</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c979" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c979">
                       <label class="govuk-label govuk-checkboxes__label" for="c979">Finding a job</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c980" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c980">
                       <label class="govuk-label govuk-checkboxes__label" for="c980">Recruiting and hiring</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c981" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c981">
                       <label class="govuk-label govuk-checkboxes__label" for="c981">State Pension</label>
                     </div>
                   </li>
@@ -6256,43 +6256,43 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c982" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c982">
                   <label class="govuk-label govuk-checkboxes__label" for="c982">Payroll</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c983" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c983">
                   <label class="govuk-label govuk-checkboxes__label" for="c983">Pensions and ageing society</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c984" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c984">
                       <label class="govuk-label govuk-checkboxes__label" for="c984">Public service pensions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c985" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c985">
                       <label class="govuk-label govuk-checkboxes__label" for="c985">Older people</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c986" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c986">
                       <label class="govuk-label govuk-checkboxes__label" for="c986">State Pension age</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c987" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c987">
                       <label class="govuk-label govuk-checkboxes__label" for="c987">State Pension simplification</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c988" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c988">
                       <label class="govuk-label govuk-checkboxes__label" for="c988">Automatic enrolment in workplace pensions</label>
                     </div>
                   </li>
@@ -6300,13 +6300,13 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c989" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c989">
                   <label class="govuk-label govuk-checkboxes__label" for="c989">Trade unions</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c990" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c990">
                   <label class="govuk-label govuk-checkboxes__label" for="c990">Health and safety at work</label>
                 </div>
               </li>
@@ -6314,43 +6314,43 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c991" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c991">
               <label class="govuk-label govuk-checkboxes__label" for="c991">Money</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c992" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c992">
                   <label class="govuk-label govuk-checkboxes__label" for="c992">Expenses and employee benefits</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c993" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c993">
                   <label class="govuk-label govuk-checkboxes__label" for="c993">Court claims, debt and bankruptcy</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c994" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c994">
                   <label class="govuk-label govuk-checkboxes__label" for="c994">Money laundering regulations</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c995" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c995">
                       <label class="govuk-label govuk-checkboxes__label" for="c995">Registration for specific business types</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c996" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c996">
                       <label class="govuk-label govuk-checkboxes__label" for="c996">Problems and compliance checks</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c997" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c997">
                       <label class="govuk-label govuk-checkboxes__label" for="c997">Your role under the regulations</label>
                     </div>
                   </li>
@@ -6358,25 +6358,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c998" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c998">
                   <label class="govuk-label govuk-checkboxes__label" for="c998">Business tax</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c999" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c999">
                       <label class="govuk-label govuk-checkboxes__label" for="c999">Large and mid-size business</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1000" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1000">
                           <label class="govuk-label govuk-checkboxes__label" for="c1000">Large businesses</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1001" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1001">
                           <label class="govuk-label govuk-checkboxes__label" for="c1001">Mid-sized businesses</label>
                         </div>
                       </li>
@@ -6384,55 +6384,55 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1002" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1002">
                       <label class="govuk-label govuk-checkboxes__label" for="c1002">PAYE</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1003" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1003">
                           <label class="govuk-label govuk-checkboxes__label" for="c1003">Statutory pay and leave</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1004" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1004">
                           <label class="govuk-label govuk-checkboxes__label" for="c1004">Special types of employee pay</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1005" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1005">
                           <label class="govuk-label govuk-checkboxes__label" for="c1005">Changes to the business that affect PAYE</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1006" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1006">
                           <label class="govuk-label govuk-checkboxes__label" for="c1006">Employees joining, leaving or changing their circumstances</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1007" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1007">
                           <label class="govuk-label govuk-checkboxes__label" for="c1007">Expenses and benefits</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1008" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1008">
                           <label class="govuk-label govuk-checkboxes__label" for="c1008">Annual PAYE and payroll tasks</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1009" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1009">
                           <label class="govuk-label govuk-checkboxes__label" for="c1009">Paying HMRC</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1010" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1010">
                           <label class="govuk-label govuk-checkboxes__label" for="c1010">Registering and getting started</label>
                         </div>
                       </li>
@@ -6440,31 +6440,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1011" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1011">
                       <label class="govuk-label govuk-checkboxes__label" for="c1011">Life insurance policies</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1012" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1012">
                       <label class="govuk-label govuk-checkboxes__label" for="c1012">IR35: working through an intermediary</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1013" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1013">
                           <label class="govuk-label govuk-checkboxes__label" for="c1013">Employment intermediaries</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1014" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1014">
                           <label class="govuk-label govuk-checkboxes__label" for="c1014">Off-payroll working rules</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1015" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1015">
                           <label class="govuk-label govuk-checkboxes__label" for="c1015">Employment status</label>
                         </div>
                       </li>
@@ -6472,25 +6472,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1016" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1016">
                       <label class="govuk-label govuk-checkboxes__label" for="c1016">Capital allowances</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1017" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1017">
                       <label class="govuk-label govuk-checkboxes__label" for="c1017">Stamp duty on shares</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1018" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1018">
                           <label class="govuk-label govuk-checkboxes__label" for="c1018">Stamp tax on electronic shares</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1019" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1019">
                           <label class="govuk-label govuk-checkboxes__label" for="c1019">Stamp tax on paper shares</label>
                         </div>
                       </li>
@@ -6498,19 +6498,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1020" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1020">
                       <label class="govuk-label govuk-checkboxes__label" for="c1020">Air Passenger Duty</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1021" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1021">
                       <label class="govuk-label govuk-checkboxes__label" for="c1021">Aggregates Levy</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1022" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1022">
                           <label class="govuk-label govuk-checkboxes__label" for="c1022">Payments and reliefs (aggregates levy)</label>
                         </div>
                       </li>
@@ -6518,25 +6518,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1023" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1023">
                       <label class="govuk-label govuk-checkboxes__label" for="c1023">Construction Industry Scheme (CIS)</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1024" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1024">
                           <label class="govuk-label govuk-checkboxes__label" for="c1024">Payments</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1025" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1025">
                           <label class="govuk-label govuk-checkboxes__label" for="c1025">Contractors</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1026" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1026">
                           <label class="govuk-label govuk-checkboxes__label" for="c1026">Subcontractors</label>
                         </div>
                       </li>
@@ -6544,31 +6544,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1027" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1027">
                       <label class="govuk-label govuk-checkboxes__label" for="c1027">Employment related securities</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1028" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1028">
                           <label class="govuk-label govuk-checkboxes__label" for="c1028">SAYE bonus rates</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1029" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1029">
                           <label class="govuk-label govuk-checkboxes__label" for="c1029">National Insurance transfers</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1030" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1030">
                           <label class="govuk-label govuk-checkboxes__label" for="c1030">Asset valuation</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1031" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1031">
                           <label class="govuk-label govuk-checkboxes__label" for="c1031">Returns and notifications</label>
                         </div>
                       </li>
@@ -6576,13 +6576,13 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1032" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1032">
                       <label class="govuk-label govuk-checkboxes__label" for="c1032">Landfill Tax</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1033" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1033">
                           <label class="govuk-label govuk-checkboxes__label" for="c1033">Payments and reliefs (landfill tax)</label>
                         </div>
                       </li>
@@ -6590,43 +6590,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1034" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1034">
                       <label class="govuk-label govuk-checkboxes__label" for="c1034">Gambling duties</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1035" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1035">
                           <label class="govuk-label govuk-checkboxes__label" for="c1035">Paying HMRC</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1036" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1036">
                           <label class="govuk-label govuk-checkboxes__label" for="c1036">General Betting Duty, Pool Betting Duty and Remote Gaming Duty</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1037" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1037">
                           <label class="govuk-label govuk-checkboxes__label" for="c1037">Machine Games Duty</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1038" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1038">
                           <label class="govuk-label govuk-checkboxes__label" for="c1038">Lottery Duty</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1039" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1039">
                           <label class="govuk-label govuk-checkboxes__label" for="c1039">Gaming Duty</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1040" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1040">
                           <label class="govuk-label govuk-checkboxes__label" for="c1040">Bingo Duty</label>
                         </div>
                       </li>
@@ -6634,19 +6634,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1041" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1041">
                       <label class="govuk-label govuk-checkboxes__label" for="c1041">Tobacco Products Duty</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1042" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1042">
                           <label class="govuk-label govuk-checkboxes__label" for="c1042">Payments and reliefs (tobacco products duty)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1043" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1043">
                           <label class="govuk-label govuk-checkboxes__label" for="c1043">Moving and storing goods</label>
                         </div>
                       </li>
@@ -6654,19 +6654,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1044" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1044">
                       <label class="govuk-label govuk-checkboxes__label" for="c1044">Investment schemes</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1045" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1045">
                           <label class="govuk-label govuk-checkboxes__label" for="c1045">Collective Investment Schemes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1046" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1046">
                           <label class="govuk-label govuk-checkboxes__label" for="c1046">Venture capital schemes</label>
                         </div>
                       </li>
@@ -6674,37 +6674,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1047" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1047">
                       <label class="govuk-label govuk-checkboxes__label" for="c1047">Stamp duty and other tax on property</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1048" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1048">
                           <label class="govuk-label govuk-checkboxes__label" for="c1048">Filing a SDLT return</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1049" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1049">
                           <label class="govuk-label govuk-checkboxes__label" for="c1049">Annual Tax on Enveloped Dwellings</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1050" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1050">
                           <label class="govuk-label govuk-checkboxes__label" for="c1050">Stamp Duty before December 2003</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1051" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1051">
                           <label class="govuk-label govuk-checkboxes__label" for="c1051">SDLT on specific transactions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1052" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1052">
                           <label class="govuk-label govuk-checkboxes__label" for="c1052">Pay your SDLT bill</label>
                         </div>
                       </li>
@@ -6712,19 +6712,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1053" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1053">
                       <label class="govuk-label govuk-checkboxes__label" for="c1053">Alcohol duties</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1054" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1054">
                           <label class="govuk-label govuk-checkboxes__label" for="c1054">Payments and reliefs (Alcohol duty)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1055" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1055">
                           <label class="govuk-label govuk-checkboxes__label" for="c1055">Moving and storing goods</label>
                         </div>
                       </li>
@@ -6732,19 +6732,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1056" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1056">
                       <label class="govuk-label govuk-checkboxes__label" for="c1056">Fuel Duty</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1057" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1057">
                           <label class="govuk-label govuk-checkboxes__label" for="c1057">Payments and reliefs (Fuel duty)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1058" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1058">
                           <label class="govuk-label govuk-checkboxes__label" for="c1058">Moving and storing goods</label>
                         </div>
                       </li>
@@ -6752,25 +6752,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1059" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1059">
                       <label class="govuk-label govuk-checkboxes__label" for="c1059">International tax</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1060" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1060">
                           <label class="govuk-label govuk-checkboxes__label" for="c1060">Oil and gas</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1061" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1061">
                           <label class="govuk-label govuk-checkboxes__label" for="c1061">Shipping</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1062" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1062">
                           <label class="govuk-label govuk-checkboxes__label" for="c1062">Double taxation</label>
                         </div>
                       </li>
@@ -6778,43 +6778,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1063" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1063">
                       <label class="govuk-label govuk-checkboxes__label" for="c1063">Corporation Tax</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1064" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1064">
                           <label class="govuk-label govuk-checkboxes__label" for="c1064">Filing your return</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1065" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1065">
                           <label class="govuk-label govuk-checkboxes__label" for="c1065">Changes to your company</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1066" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1066">
                           <label class="govuk-label govuk-checkboxes__label" for="c1066">Payments and refunds</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1067" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1067">
                           <label class="govuk-label govuk-checkboxes__label" for="c1067">Working out your Corporation Tax</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1068" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1068">
                           <label class="govuk-label govuk-checkboxes__label" for="c1068">Reliefs</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1069" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1069">
                           <label class="govuk-label govuk-checkboxes__label" for="c1069">Preparing accounts for Corporation Tax</label>
                         </div>
                       </li>
@@ -6822,37 +6822,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1070" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1070">
                       <label class="govuk-label govuk-checkboxes__label" for="c1070">Pension scheme administration</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1071" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1071">
                           <label class="govuk-label govuk-checkboxes__label" for="c1071">Overseas schemes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1072" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1072">
                           <label class="govuk-label govuk-checkboxes__label" for="c1072">Tax on pensions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1073" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1073">
                           <label class="govuk-label govuk-checkboxes__label" for="c1073">Paying into a pension scheme</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1074" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1074">
                           <label class="govuk-label govuk-checkboxes__label" for="c1074">Administering a pension scheme</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1075" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1075">
                           <label class="govuk-label govuk-checkboxes__label" for="c1075">Pension scheme trustees</label>
                         </div>
                       </li>
@@ -6860,73 +6860,73 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1076" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1076">
                       <label class="govuk-label govuk-checkboxes__label" for="c1076">VAT</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1077" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1077">
                           <label class="govuk-label govuk-checkboxes__label" for="c1077">Rules for particular trades</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1078" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1078">
                           <label class="govuk-label govuk-checkboxes__label" for="c1078">Exporting goods and services</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1079" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1079">
                           <label class="govuk-label govuk-checkboxes__label" for="c1079">Importing goods and services</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1080" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1080">
                           <label class="govuk-label govuk-checkboxes__label" for="c1080">Overseas businesses and UK VAT</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1081" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1081">
                           <label class="govuk-label govuk-checkboxes__label" for="c1081">Charging VAT</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1082" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1082">
                           <label class="govuk-label govuk-checkboxes__label" for="c1082">VAT MOSS</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1083" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1083">
                           <label class="govuk-label govuk-checkboxes__label" for="c1083">Reclaiming VAT on a new home</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1084" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1084">
                           <label class="govuk-label govuk-checkboxes__label" for="c1084">VAT returns</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1085" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1085">
                           <label class="govuk-label govuk-checkboxes__label" for="c1085">Paying</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1086" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1086">
                           <label class="govuk-label govuk-checkboxes__label" for="c1086">Exchange rates</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1087" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1087">
                           <label class="govuk-label govuk-checkboxes__label" for="c1087">Accounting for VAT</label>
                         </div>
                       </li>
@@ -6934,25 +6934,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1088" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1088">
                       <label class="govuk-label govuk-checkboxes__label" for="c1088">Business tax reform</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1089" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1089">
                       <label class="govuk-label govuk-checkboxes__label" for="c1089">Climate Change Levy</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1090" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1090">
                       <label class="govuk-label govuk-checkboxes__label" for="c1090">Insurance Premium Tax</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1091" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1091">
                           <label class="govuk-label govuk-checkboxes__label" for="c1091">Paying Insurance Premium Tax</label>
                         </div>
                       </li>
@@ -6962,121 +6962,121 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1092" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1092">
                   <label class="govuk-label govuk-checkboxes__label" for="c1092">Dealing with HMRC</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1093" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1093">
                       <label class="govuk-label govuk-checkboxes__label" for="c1093">Paying HMRC</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1094" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1094">
                           <label class="govuk-label govuk-checkboxes__label" for="c1094">PAYE</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1095" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1095">
                           <label class="govuk-label govuk-checkboxes__label" for="c1095">Payment problems</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1096" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1096">
                           <label class="govuk-label govuk-checkboxes__label" for="c1096">Transport and environmental duties</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1097" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1097">
                           <label class="govuk-label govuk-checkboxes__label" for="c1097">Tax credit overpayments</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1098" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1098">
                           <label class="govuk-label govuk-checkboxes__label" for="c1098">VAT</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1099" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1099">
                           <label class="govuk-label govuk-checkboxes__label" for="c1099">Property taxes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1100" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1100">
                           <label class="govuk-label govuk-checkboxes__label" for="c1100">Shares</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1101" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1101">
                           <label class="govuk-label govuk-checkboxes__label" for="c1101">Pension schemes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1102" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1102">
                           <label class="govuk-label govuk-checkboxes__label" for="c1102">Money laundering regulation fees</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1103" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1103">
                           <label class="govuk-label govuk-checkboxes__label" for="c1103">Insurance Premium Tax</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1104" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1104">
                           <label class="govuk-label govuk-checkboxes__label" for="c1104">Inheritance Tax</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1105" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1105">
                           <label class="govuk-label govuk-checkboxes__label" for="c1105">Gambling duties</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1106" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1106">
                           <label class="govuk-label govuk-checkboxes__label" for="c1106">Income Tax and National Insurance</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1107" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1107">
                           <label class="govuk-label govuk-checkboxes__label" for="c1107">Corporation Tax</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1108" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1108">
                           <label class="govuk-label govuk-checkboxes__label" for="c1108">Construction Industry Scheme (through PAYE)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1109" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1109">
                           <label class="govuk-label govuk-checkboxes__label" for="c1109">Child Benefit overpayments</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1110" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1110">
                           <label class="govuk-label govuk-checkboxes__label" for="c1110">Alcohol duties</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1111" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1111">
                           <label class="govuk-label govuk-checkboxes__label" for="c1111">Capital Gains Tax</label>
                         </div>
                       </li>
@@ -7084,43 +7084,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1112" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1112">
                       <label class="govuk-label govuk-checkboxes__label" for="c1112">Phishing and scams</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1113" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1113">
                       <label class="govuk-label govuk-checkboxes__label" for="c1113">Shared Workspace service</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1114" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1114">
                       <label class="govuk-label govuk-checkboxes__label" for="c1114">Complaints and appeals</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1115" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1115">
                       <label class="govuk-label govuk-checkboxes__label" for="c1115">Tax avoidance</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1116" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1116">
                           <label class="govuk-label govuk-checkboxes__label" for="c1116">Disguised remuneration schemes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1117" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1117">
                           <label class="govuk-label govuk-checkboxes__label" for="c1117">Disclosing avoidance schemes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1118" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1118">
                           <label class="govuk-label govuk-checkboxes__label" for="c1118">Identifying avoidance schemes</label>
                         </div>
                       </li>
@@ -7128,49 +7128,49 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1119" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1119">
                       <label class="govuk-label govuk-checkboxes__label" for="c1119">Tax compliance</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1120" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1120">
                           <label class="govuk-label govuk-checkboxes__label" for="c1120">International agreements and FATCA</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1121" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1121">
                           <label class="govuk-label govuk-checkboxes__label" for="c1121">Clearances and approvals</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1122" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1122">
                           <label class="govuk-label govuk-checkboxes__label" for="c1122">Disclosing offshore income</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1123" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1123">
                           <label class="govuk-label govuk-checkboxes__label" for="c1123">Reporting tax evasion</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1124" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1124">
                           <label class="govuk-label govuk-checkboxes__label" for="c1124">Non-payment and fraud</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1125" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1125">
                           <label class="govuk-label govuk-checkboxes__label" for="c1125">Disputes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1126" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1126">
                           <label class="govuk-label govuk-checkboxes__label" for="c1126">Compliance checks</label>
                         </div>
                       </li>
@@ -7178,37 +7178,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1127" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1127">
                       <label class="govuk-label govuk-checkboxes__label" for="c1127">Tax agent and adviser guidance</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1128" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1128">
                           <label class="govuk-label govuk-checkboxes__label" for="c1128">Money laundering regulations</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1129" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1129">
                           <label class="govuk-label govuk-checkboxes__label" for="c1129">Working with HMRC - joint initiatives</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1130" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1130">
                           <label class="govuk-label govuk-checkboxes__label" for="c1130">Appeals and penalties</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1131" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1131">
                           <label class="govuk-label govuk-checkboxes__label" for="c1131">Compliance checks</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1132" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1132">
                           <label class="govuk-label govuk-checkboxes__label" for="c1132">Agent authorisation</label>
                         </div>
                       </li>
@@ -7216,31 +7216,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1133" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1133">
                       <label class="govuk-label govuk-checkboxes__label" for="c1133">Software development for HMRC</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1134" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1134">
                           <label class="govuk-label govuk-checkboxes__label" for="c1134">Working in partnership</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1135" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1135">
                           <label class="govuk-label govuk-checkboxes__label" for="c1135">HMRC recognition scheme</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1136" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1136">
                           <label class="govuk-label govuk-checkboxes__label" for="c1136">New to HMRC development</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1137" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1137">
                           <label class="govuk-label govuk-checkboxes__label" for="c1137">Software development support</label>
                         </div>
                       </li>
@@ -7250,37 +7250,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1138" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1138">
                   <label class="govuk-label govuk-checkboxes__label" for="c1138">Personal tax</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1139" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1139">
                       <label class="govuk-label govuk-checkboxes__label" for="c1139">Inheritance Tax</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1140" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1140">
                           <label class="govuk-label govuk-checkboxes__label" for="c1140">Reliefs</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1141" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1141">
                           <label class="govuk-label govuk-checkboxes__label" for="c1141">Paying HMRC</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1142" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1142">
                           <label class="govuk-label govuk-checkboxes__label" for="c1142">Working out the tax</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1143" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1143">
                           <label class="govuk-label govuk-checkboxes__label" for="c1143">Wills and probate</label>
                         </div>
                       </li>
@@ -7288,31 +7288,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1144" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1144">
                       <label class="govuk-label govuk-checkboxes__label" for="c1144">National Insurance</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1145" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1145">
                           <label class="govuk-label govuk-checkboxes__label" for="c1145">Voluntary contributions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1146" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1146">
                           <label class="govuk-label govuk-checkboxes__label" for="c1146">Rates and classes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1147" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1147">
                           <label class="govuk-label govuk-checkboxes__label" for="c1147">Refunds</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1148" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1148">
                           <label class="govuk-label govuk-checkboxes__label" for="c1148">National Insurance numbers</label>
                         </div>
                       </li>
@@ -7320,55 +7320,55 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1149" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1149">
                       <label class="govuk-label govuk-checkboxes__label" for="c1149">Foreign entertainer tax rules</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1150" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1150">
                       <label class="govuk-label govuk-checkboxes__label" for="c1150">Coming to the UK</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1151" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1151">
                       <label class="govuk-label govuk-checkboxes__label" for="c1151">Capital Gains Tax</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1152" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1152">
                           <label class="govuk-label govuk-checkboxes__label" for="c1152">Paying HMRC</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1153" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1153">
                           <label class="govuk-label govuk-checkboxes__label" for="c1153">Divorce and separation</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1154" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1154">
                           <label class="govuk-label govuk-checkboxes__label" for="c1154">Business</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1155" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1155">
                           <label class="govuk-label govuk-checkboxes__label" for="c1155">Shares and investments</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1156" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1156">
                           <label class="govuk-label govuk-checkboxes__label" for="c1156">Property</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1157" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1157">
                           <label class="govuk-label govuk-checkboxes__label" for="c1157">Personal possessions</label>
                         </div>
                       </li>
@@ -7376,49 +7376,49 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1158" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1158">
                       <label class="govuk-label govuk-checkboxes__label" for="c1158">Income Tax</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1159" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1159">
                           <label class="govuk-label govuk-checkboxes__label" for="c1159">Scottish rate of Income Tax</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1160" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1160">
                           <label class="govuk-label govuk-checkboxes__label" for="c1160">Pensions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1161" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1161">
                           <label class="govuk-label govuk-checkboxes__label" for="c1161">Company benefits and share schemes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1162" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1162">
                           <label class="govuk-label govuk-checkboxes__label" for="c1162">Student jobs and loans</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1163" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1163">
                           <label class="govuk-label govuk-checkboxes__label" for="c1163">Special types of pay</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1164" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1164">
                           <label class="govuk-label govuk-checkboxes__label" for="c1164">Overpayments and underpayments</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1165" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1165">
                           <label class="govuk-label govuk-checkboxes__label" for="c1165">Rates, allowances and reliefs</label>
                         </div>
                       </li>
@@ -7426,37 +7426,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1166" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1166">
                       <label class="govuk-label govuk-checkboxes__label" for="c1166">Self Assessment</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1167" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1167">
                           <label class="govuk-label govuk-checkboxes__label" for="c1167">Refunds, appeals and penalties</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1168" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1168">
                           <label class="govuk-label govuk-checkboxes__label" for="c1168">Paying your tax bill</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1169" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1169">
                           <label class="govuk-label govuk-checkboxes__label" for="c1169">Records you must keep</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1170" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1170">
                           <label class="govuk-label govuk-checkboxes__label" for="c1170">Filing a tax return</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1171" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1171">
                           <label class="govuk-label govuk-checkboxes__label" for="c1171">Registering for Self Assessment</label>
                         </div>
                       </li>
@@ -7464,49 +7464,49 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1172" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1172">
                       <label class="govuk-label govuk-checkboxes__label" for="c1172">Non-resident landlord scheme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1173" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1173">
                       <label class="govuk-label govuk-checkboxes__label" for="c1173">Leaving the UK</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1174" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1174">
                       <label class="govuk-label govuk-checkboxes__label" for="c1174">Trusts</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1175" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1175">
                       <label class="govuk-label govuk-checkboxes__label" for="c1175">Tax on savings and investments</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1176" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1176">
                           <label class="govuk-label govuk-checkboxes__label" for="c1176">Guidance for financial institutions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1177" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1177">
                           <label class="govuk-label govuk-checkboxes__label" for="c1177">Tax efficient savings and investments</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1178" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1178">
                           <label class="govuk-label govuk-checkboxes__label" for="c1178">Tax on shares</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1179" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1179">
                           <label class="govuk-label govuk-checkboxes__label" for="c1179">Tax on savings</label>
                         </div>
                       </li>
@@ -7514,19 +7514,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1180" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1180">
                       <label class="govuk-label govuk-checkboxes__label" for="c1180">Living or working abroad or offshore</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1181" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1181">
                           <label class="govuk-label govuk-checkboxes__label" for="c1181">Rules for specific occupations</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1182" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1182">
                           <label class="govuk-label govuk-checkboxes__label" for="c1182">Living and working abroad</label>
                         </div>
                       </li>
@@ -7534,7 +7534,7 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1183" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1183">
                       <label class="govuk-label govuk-checkboxes__label" for="c1183">Personal tax reform</label>
                     </div>
                   </li>
@@ -7542,7 +7542,7 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1184" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1184">
                   <label class="govuk-label govuk-checkboxes__label" for="c1184">Tax evasion and avoidance</label>
                 </div>
               </li>
@@ -7550,55 +7550,55 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c1185" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c1185">
               <label class="govuk-label govuk-checkboxes__label" for="c1185">Business and industry</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1186" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1186">
                   <label class="govuk-label govuk-checkboxes__label" for="c1186">Running a business</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1187" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1187">
                       <label class="govuk-label govuk-checkboxes__label" for="c1187">Business debt and bankruptcy</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1188" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1188">
                       <label class="govuk-label govuk-checkboxes__label" for="c1188">Business licensing</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1189" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1189">
                       <label class="govuk-label govuk-checkboxes__label" for="c1189">Business auditing, accounting and reporting</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1190" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1190">
                       <label class="govuk-label govuk-checkboxes__label" for="c1190">Employing people</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1191" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1191">
                           <label class="govuk-label govuk-checkboxes__label" for="c1191">Dismissing staff and redundancies</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1192" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1192">
                           <label class="govuk-label govuk-checkboxes__label" for="c1192">Payroll</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1193" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1193">
                           <label class="govuk-label govuk-checkboxes__label" for="c1193">Recruiting and hiring</label>
                         </div>
                       </li>
@@ -7606,31 +7606,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1194" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1194">
                       <label class="govuk-label govuk-checkboxes__label" for="c1194">Limited companies and partnerships</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1195" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1195">
                           <label class="govuk-label govuk-checkboxes__label" for="c1195">Partnerships</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1196" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1196">
                           <label class="govuk-label govuk-checkboxes__label" for="c1196">Company names</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1197" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1197">
                           <label class="govuk-label govuk-checkboxes__label" for="c1197">Overseas companies and European companies</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1198" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1198">
                           <label class="govuk-label govuk-checkboxes__label" for="c1198">Company closure, administration, liquidation and insolvency</label>
                         </div>
                       </li>
@@ -7638,13 +7638,13 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1199" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1199">
                       <label class="govuk-label govuk-checkboxes__label" for="c1199">Business finance and support</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1200" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1200">
                       <label class="govuk-label govuk-checkboxes__label" for="c1200">Business premises and business rates</label>
                     </div>
                   </li>
@@ -7652,37 +7652,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1201" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1201">
                   <label class="govuk-label govuk-checkboxes__label" for="c1201">Corporate governance</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1202" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1202">
                   <label class="govuk-label govuk-checkboxes__label" for="c1202">Business regulation</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1203" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1203">
                       <label class="govuk-label govuk-checkboxes__label" for="c1203">Consumer rights and issues</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1204" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1204">
                           <label class="govuk-label govuk-checkboxes__label" for="c1204">Consumer credit market</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1205" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1205">
                           <label class="govuk-label govuk-checkboxes__label" for="c1205">Gambling regulation</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1206" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1206">
                           <label class="govuk-label govuk-checkboxes__label" for="c1206">Consumer protection</label>
                         </div>
                       </li>
@@ -7690,13 +7690,13 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1207" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1207">
                       <label class="govuk-label govuk-checkboxes__label" for="c1207">Regulation reform</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1208" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1208">
                           <label class="govuk-label govuk-checkboxes__label" for="c1208">Company law reform</label>
                         </div>
                       </li>
@@ -7704,49 +7704,49 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1209" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1209">
                       <label class="govuk-label govuk-checkboxes__label" for="c1209">Sale of goods and services and data protection</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1210" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1210">
                       <label class="govuk-label govuk-checkboxes__label" for="c1210">Energy industry and infrastructure licensing and regulation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1211" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1211">
                       <label class="govuk-label govuk-checkboxes__label" for="c1211">Alcohol licensing</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1212" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1212">
                       <label class="govuk-label govuk-checkboxes__label" for="c1212">Intellectual property</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1213" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1213">
                           <label class="govuk-label govuk-checkboxes__label" for="c1213">Copyright</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1214" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1214">
                           <label class="govuk-label govuk-checkboxes__label" for="c1214">Patents</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1215" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1215">
                           <label class="govuk-label govuk-checkboxes__label" for="c1215">Designs</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1216" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1216">
                           <label class="govuk-label govuk-checkboxes__label" for="c1216">Trade marks</label>
                         </div>
                       </li>
@@ -7754,43 +7754,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1217" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1217">
                       <label class="govuk-label govuk-checkboxes__label" for="c1217">Competition</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1218" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1218">
                           <label class="govuk-label govuk-checkboxes__label" for="c1218">Competition law</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1219" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1219">
                           <label class="govuk-label govuk-checkboxes__label" for="c1219">Regulatory appeals and references</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1220" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1220">
                           <label class="govuk-label govuk-checkboxes__label" for="c1220">Mergers</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1221" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1221">
                           <label class="govuk-label govuk-checkboxes__label" for="c1221">Markets</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1222" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1222">
                           <label class="govuk-label govuk-checkboxes__label" for="c1222">Consumer protection</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1223" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1223">
                           <label class="govuk-label govuk-checkboxes__label" for="c1223">Competition Act and cartels</label>
                         </div>
                       </li>
@@ -7800,31 +7800,31 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1224" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1224">
                   <label class="govuk-label govuk-checkboxes__label" for="c1224">Charities and social enterprises</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1225" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1225">
                       <label class="govuk-label govuk-checkboxes__label" for="c1225">Trustee role and board</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1226" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1226">
                       <label class="govuk-label govuk-checkboxes__label" for="c1226">Fundraising</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1227" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1227">
                       <label class="govuk-label govuk-checkboxes__label" for="c1227">Charity money, tax and accounts</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1228" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1228">
                       <label class="govuk-label govuk-checkboxes__label" for="c1228">Community interest companies</label>
                     </div>
                   </li>
@@ -7832,25 +7832,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1229" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1229">
                   <label class="govuk-label govuk-checkboxes__label" for="c1229">Science and innovation</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1230" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1230">
                       <label class="govuk-label govuk-checkboxes__label" for="c1230">Scientific research and development</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1231" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1231">
                       <label class="govuk-label govuk-checkboxes__label" for="c1231">Research and development</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1232" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1232">
                       <label class="govuk-label govuk-checkboxes__label" for="c1232">Animal research and testing</label>
                     </div>
                   </li>
@@ -7858,49 +7858,49 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1233" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1233">
                   <label class="govuk-label govuk-checkboxes__label" for="c1233">Trade and investment</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1234" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1234">
                       <label class="govuk-label govuk-checkboxes__label" for="c1234">Customs declarations, duties and tariffs (import and export)</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1235" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1235">
                           <label class="govuk-label govuk-checkboxes__label" for="c1235">Commodity codes and reporting</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1236" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1236">
                           <label class="govuk-label govuk-checkboxes__label" for="c1236">Customs Freight Simplified Procedures</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1237" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1237">
                           <label class="govuk-label govuk-checkboxes__label" for="c1237">Rules for specific goods and services</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1238" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1238">
                           <label class="govuk-label govuk-checkboxes__label" for="c1238">UK Trade Tariff and classification of goods</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1239" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1239">
                           <label class="govuk-label govuk-checkboxes__label" for="c1239">Exchange rates</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1240" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1240">
                           <label class="govuk-label govuk-checkboxes__label" for="c1240">Get goods through customs</label>
                         </div>
                       </li>
@@ -7908,43 +7908,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1241" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1241">
                       <label class="govuk-label govuk-checkboxes__label" for="c1241">Free trade</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1242" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1242">
                       <label class="govuk-label govuk-checkboxes__label" for="c1242">Outward investment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1243" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1243">
                       <label class="govuk-label govuk-checkboxes__label" for="c1243">Inward investment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1244" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1244">
                       <label class="govuk-label govuk-checkboxes__label" for="c1244">Importing</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1245" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1245">
                           <label class="govuk-label govuk-checkboxes__label" for="c1245">Import controls</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1246" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1246">
                           <label class="govuk-label govuk-checkboxes__label" for="c1246">Wood packaging</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1247" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1247">
                           <label class="govuk-label govuk-checkboxes__label" for="c1247">Commodity codes and reporting</label>
                         </div>
                       </li>
@@ -7952,43 +7952,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1248" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1248">
                       <label class="govuk-label govuk-checkboxes__label" for="c1248">Trade barriers</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1249" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1249">
                       <label class="govuk-label govuk-checkboxes__label" for="c1249">Exporting</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1250" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1250">
                           <label class="govuk-label govuk-checkboxes__label" for="c1250">Embargoes and sanctions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1251" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1251">
                           <label class="govuk-label govuk-checkboxes__label" for="c1251">Export finance</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1252" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1252">
                           <label class="govuk-label govuk-checkboxes__label" for="c1252">Export controls and licensing</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1253" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1253">
                           <label class="govuk-label govuk-checkboxes__label" for="c1253">Licences and special rules</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1254" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1254">
                           <label class="govuk-label govuk-checkboxes__label" for="c1254">Trade restrictions on exports</label>
                         </div>
                       </li>
@@ -7996,7 +7996,7 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1255" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1255">
                       <label class="govuk-label govuk-checkboxes__label" for="c1255">Digital trade</label>
                     </div>
                   </li>
@@ -8004,49 +8004,49 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1256" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1256">
                   <label class="govuk-label govuk-checkboxes__label" for="c1256">Manufacturing</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1257" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1257">
                   <label class="govuk-label govuk-checkboxes__label" for="c1257">UK economy</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1258" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1258">
                       <label class="govuk-label govuk-checkboxes__label" for="c1258">Regional growth fund</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1259" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1259">
                       <label class="govuk-label govuk-checkboxes__label" for="c1259">City deals and growth deals</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1260" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1260">
                       <label class="govuk-label govuk-checkboxes__label" for="c1260">UK economic growth</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1261" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1261">
                           <label class="govuk-label govuk-checkboxes__label" for="c1261">Economic development in coastal and seaside areas</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1262" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1262">
                           <label class="govuk-label govuk-checkboxes__label" for="c1262">Local Enterprise Partnerships (LEPs) and Enterprise Zones</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1263" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1263">
                           <label class="govuk-label govuk-checkboxes__label" for="c1263">Management of the European Regional Development Fund</label>
                         </div>
                       </li>
@@ -8056,25 +8056,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1264" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1264">
                   <label class="govuk-label govuk-checkboxes__label" for="c1264">Industrial strategy</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1265" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1265">
                   <label class="govuk-label govuk-checkboxes__label" for="c1265">Business and the environment</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1266" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1266">
                       <label class="govuk-label govuk-checkboxes__label" for="c1266">Energy demand reduction</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1267" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1267">
                       <label class="govuk-label govuk-checkboxes__label" for="c1267">UK energy security</label>
                     </div>
                   </li>
@@ -8082,25 +8082,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1268" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1268">
                   <label class="govuk-label govuk-checkboxes__label" for="c1268">Media and communications</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1269" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1269">
                       <label class="govuk-label govuk-checkboxes__label" for="c1269">Media and creative industries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1270" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1270">
                       <label class="govuk-label govuk-checkboxes__label" for="c1270">Broadband investment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1271" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1271">
                       <label class="govuk-label govuk-checkboxes__label" for="c1271">Communications and telecomms</label>
                     </div>
                   </li>
@@ -8108,25 +8108,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1272" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1272">
                   <label class="govuk-label govuk-checkboxes__label" for="c1272">Financial services</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1273" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1273">
                       <label class="govuk-label govuk-checkboxes__label" for="c1273">Financial services regulation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1274" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1274">
                       <label class="govuk-label govuk-checkboxes__label" for="c1274">Access to financial services</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1275" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1275">
                       <label class="govuk-label govuk-checkboxes__label" for="c1275">Bank regulation</label>
                     </div>
                   </li>

--- a/examples/index.html
+++ b/examples/index.html
@@ -24,37 +24,37 @@
         <ul id="taxonomy" class="govuk-list">
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c0" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c0">
               <label class="govuk-label govuk-checkboxes__label" for="c0">Entering and staying in the UK</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1">
                   <label class="govuk-label govuk-checkboxes__label" for="c1">Travel and identity documents for foreign nationals</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c2" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c2">
                   <label class="govuk-label govuk-checkboxes__label" for="c2">Immigration offences</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c3" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c3">
                       <label class="govuk-label govuk-checkboxes__label" for="c3">Deportation, removals and curtailment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c4" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c4">
                       <label class="govuk-label govuk-checkboxes__label" for="c4">Immigration detention</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c5" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c5">
                       <label class="govuk-label govuk-checkboxes__label" for="c5">Immigration penalties</label>
                     </div>
                   </li>
@@ -62,37 +62,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c6" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c6">
                   <label class="govuk-label govuk-checkboxes__label" for="c6">Immigration adviser services</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c7" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c7">
                   <label class="govuk-label govuk-checkboxes__label" for="c7">Rights of foreign nationals in the UK</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c8" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c8">
                       <label class="govuk-label govuk-checkboxes__label" for="c8">Rights of nationals from outside the EU and EEA</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c9" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c9">
                       <label class="govuk-label govuk-checkboxes__label" for="c9">Foreign nationals working in the UK</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c10" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c10">
                       <label class="govuk-label govuk-checkboxes__label" for="c10">Right to rent in the UK</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c11" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c11">
                       <label class="govuk-label govuk-checkboxes__label" for="c11">Rights of EU and EEA citizens</label>
                     </div>
                   </li>
@@ -100,49 +100,49 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c12" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c12">
                   <label class="govuk-label govuk-checkboxes__label" for="c12">Visas and immigration corporate</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c13" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c13">
                   <label class="govuk-label govuk-checkboxes__label" for="c13">Border control</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c14" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c14">
                   <label class="govuk-label govuk-checkboxes__label" for="c14">Immigration rules</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c15" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c15">
                   <label class="govuk-label govuk-checkboxes__label" for="c15">Refugees, asylum and human rights</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c16" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c16">
                       <label class="govuk-label govuk-checkboxes__label" for="c16">Refugee, asylum and human rights claims</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c17" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c17">
                       <label class="govuk-label govuk-checkboxes__label" for="c17">Asylum decisions and appeals</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c18" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c18">
                       <label class="govuk-label govuk-checkboxes__label" for="c18">Asylum for children</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c19" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c19">
                       <label class="govuk-label govuk-checkboxes__label" for="c19">Support for asylum claimants and refugees</label>
                     </div>
                   </li>
@@ -150,61 +150,61 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c20" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c20">
                   <label class="govuk-label govuk-checkboxes__label" for="c20">Visas and entry clearance</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c21" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c21">
                       <label class="govuk-label govuk-checkboxes__label" for="c21">Work and investor visas</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c22" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c22">
                       <label class="govuk-label govuk-checkboxes__label" for="c22">Visit and transit visas</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c23" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c23">
                       <label class="govuk-label govuk-checkboxes__label" for="c23">Visa application centres</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c24" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c24">
                       <label class="govuk-label govuk-checkboxes__label" for="c24">Visa sponsorship</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c25" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c25">
                       <label class="govuk-label govuk-checkboxes__label" for="c25">Tuberculosis (TB) testing</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c26" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c26">
                       <label class="govuk-label govuk-checkboxes__label" for="c26">Student visas</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c27" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c27">
                       <label class="govuk-label govuk-checkboxes__label" for="c27">Family visas</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c28" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c28">
                       <label class="govuk-label govuk-checkboxes__label" for="c28">Visa refusals and appeals</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c29" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c29">
                       <label class="govuk-label govuk-checkboxes__label" for="c29">Visa applications</label>
                     </div>
                   </li>
@@ -212,19 +212,19 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c30" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c30">
                   <label class="govuk-label govuk-checkboxes__label" for="c30">Permanent stay in the UK</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c31" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c31">
                       <label class="govuk-label govuk-checkboxes__label" for="c31">Citizenship</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c32" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c32">
                       <label class="govuk-label govuk-checkboxes__label" for="c32">Settlement</label>
                     </div>
                   </li>
@@ -234,31 +234,31 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c33" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c33">
               <label class="govuk-label govuk-checkboxes__label" for="c33">Going and being abroad</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c34" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c34">
                   <label class="govuk-label govuk-checkboxes__label" for="c34">Travel abroad</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c35" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c35">
                   <label class="govuk-label govuk-checkboxes__label" for="c35">Passports</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c36" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c36">
                   <label class="govuk-label govuk-checkboxes__label" for="c36">British nationals overseas</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c37" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c37">
                   <label class="govuk-label govuk-checkboxes__label" for="c37">Living abroad</label>
                 </div>
               </li>
@@ -266,67 +266,67 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c38" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c38">
               <label class="govuk-label govuk-checkboxes__label" for="c38">Education, training and skills</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c39" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c39">
                   <label class="govuk-label govuk-checkboxes__label" for="c39">Further and higher education, skills and vocational training</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c40" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c40">
                       <label class="govuk-label govuk-checkboxes__label" for="c40">Further education funding</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c41" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c41">
                           <label class="govuk-label govuk-checkboxes__label" for="c41">Administering student funding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c42" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c42">
                           <label class="govuk-label govuk-checkboxes__label" for="c42">Dance and drama funding for 16 to 19 year olds</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c43" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c43">
                           <label class="govuk-label govuk-checkboxes__label" for="c43">Further education funding data</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c44" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c44">
                           <label class="govuk-label govuk-checkboxes__label" for="c44">Free meals for 16 to 18 year olds</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c45" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c45">
                           <label class="govuk-label govuk-checkboxes__label" for="c45">European Social Fund (ESF) and skills funding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c46" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c46">
                           <label class="govuk-label govuk-checkboxes__label" for="c46">Further education buildings and land</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c47" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c47">
                           <label class="govuk-label govuk-checkboxes__label" for="c47">Apprenticeships funding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c48" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c48">
                           <label class="govuk-label govuk-checkboxes__label" for="c48">Adult education funding</label>
                         </div>
                       </li>
@@ -334,37 +334,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c49" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c49">
                       <label class="govuk-label govuk-checkboxes__label" for="c49">Apprenticeships, traineeships and internships</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c50" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c50">
                           <label class="govuk-label govuk-checkboxes__label" for="c50">Hiring and training an apprentice</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c51" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c51">
                           <label class="govuk-label govuk-checkboxes__label" for="c51">Becoming an apprentice</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c52" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c52">
                           <label class="govuk-label govuk-checkboxes__label" for="c52">Hiring and training an intern or trainee</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c53" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c53">
                           <label class="govuk-label govuk-checkboxes__label" for="c53">Types of apprenticeships</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c54" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c54">
                           <label class="govuk-label govuk-checkboxes__label" for="c54">Becoming an intern or trainee</label>
                         </div>
                       </li>
@@ -372,31 +372,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c55" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c55">
                       <label class="govuk-label govuk-checkboxes__label" for="c55">Adult and community learning</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c56" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c56">
                       <label class="govuk-label govuk-checkboxes__label" for="c56">Careers guidance in further and higher education</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c57" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c57">
                       <label class="govuk-label govuk-checkboxes__label" for="c57">Further and higher education courses and qualifications</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c58" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c58">
                           <label class="govuk-label govuk-checkboxes__label" for="c58">Functional skills</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c59" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c59">
                           <label class="govuk-label govuk-checkboxes__label" for="c59">Principal learning qualifications</label>
                         </div>
                       </li>
@@ -404,25 +404,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c60" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c60">
                       <label class="govuk-label govuk-checkboxes__label" for="c60">Further education financial management and data collection</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c61" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c61">
                           <label class="govuk-label govuk-checkboxes__label" for="c61">Data collection for further education providers</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c62" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c62">
                           <label class="govuk-label govuk-checkboxes__label" for="c62">Local authority further education financial reporting and assurance</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c63" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c63">
                           <label class="govuk-label govuk-checkboxes__label" for="c63">Financial management for further education providers</label>
                         </div>
                       </li>
@@ -430,19 +430,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c64" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c64">
                       <label class="govuk-label govuk-checkboxes__label" for="c64">Running a further or higher education institution</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c65" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c65">
                       <label class="govuk-label govuk-checkboxes__label" for="c65">Learning Records Service (LRS)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c66" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c66">
                       <label class="govuk-label govuk-checkboxes__label" for="c66">Education in prisons</label>
                     </div>
                   </li>
@@ -450,43 +450,43 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c67" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c67">
                   <label class="govuk-label govuk-checkboxes__label" for="c67">Pupil wellbeing, behaviour and attendance</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c68" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c68">
                       <label class="govuk-label govuk-checkboxes__label" for="c68">Safeguarding pupils</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c69" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c69">
                       <label class="govuk-label govuk-checkboxes__label" for="c69">School attendance and absence</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c70" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c70">
                       <label class="govuk-label govuk-checkboxes__label" for="c70">School discipline and exclusions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c71" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c71">
                       <label class="govuk-label govuk-checkboxes__label" for="c71">Health, safety and wellbeing in schools</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c72" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c72">
                       <label class="govuk-label govuk-checkboxes__label" for="c72">School bullying</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c73" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c73">
                       <label class="govuk-label govuk-checkboxes__label" for="c73">Alternative provision and pupil referral units</label>
                     </div>
                   </li>
@@ -494,37 +494,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c74" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c74">
                   <label class="govuk-label govuk-checkboxes__label" for="c74">Teaching and leadership</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c75" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c75">
                       <label class="govuk-label govuk-checkboxes__label" for="c75">Teaching standards, misconduct and practice</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c76" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c76">
                       <label class="govuk-label govuk-checkboxes__label" for="c76">Teacher training and professional development</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c77" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c77">
                           <label class="govuk-label govuk-checkboxes__label" for="c77">School leadership</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c78" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c78">
                           <label class="govuk-label govuk-checkboxes__label" for="c78">Initial Teacher Training (ITT)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c79" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c79">
                           <label class="govuk-label govuk-checkboxes__label" for="c79">Qualified Teacher Status (QTS)</label>
                         </div>
                       </li>
@@ -532,19 +532,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c80" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c80">
                       <label class="govuk-label govuk-checkboxes__label" for="c80">Recruiting, inducting and managing teachers</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c81" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c81">
                       <label class="govuk-label govuk-checkboxes__label" for="c81">Teacher pay, pensions and conditions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c82" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c82">
                       <label class="govuk-label govuk-checkboxes__label" for="c82">Teacher records</label>
                     </div>
                   </li>
@@ -552,73 +552,73 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c83" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c83">
                   <label class="govuk-label govuk-checkboxes__label" for="c83">Inspections and performance of education providers</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c84" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c84">
                       <label class="govuk-label govuk-checkboxes__label" for="c84">Inspection and performance of schools</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c85" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c85">
                           <label class="govuk-label govuk-checkboxes__label" for="c85">School intervention notices and reports</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c86" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c86">
                           <label class="govuk-label govuk-checkboxes__label" for="c86">Inspection of local authority support for schools</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c87" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c87">
                           <label class="govuk-label govuk-checkboxes__label" for="c87">School performance tables and Ofsted reports</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c88" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c88">
                           <label class="govuk-label govuk-checkboxes__label" for="c88">Inspection of maintained schools and academies</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c89" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c89">
                           <label class="govuk-label govuk-checkboxes__label" for="c89">Inspection of boarding and residential schools</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c90" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c90">
                           <label class="govuk-label govuk-checkboxes__label" for="c90">Inspection of non-maintained schools</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c91" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c91">
                           <label class="govuk-label govuk-checkboxes__label" for="c91">Inspection of British schools overseas</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c92" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c92">
                           <label class="govuk-label govuk-checkboxes__label" for="c92">School performance measures</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c93" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c93">
                           <label class="govuk-label govuk-checkboxes__label" for="c93">Inspection of independent schools</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c94" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c94">
                           <label class="govuk-label govuk-checkboxes__label" for="c94">Pupil performance in schools</label>
                         </div>
                       </li>
@@ -626,43 +626,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c95" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c95">
                       <label class="govuk-label govuk-checkboxes__label" for="c95">Inspection and performance of further education providers</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c96" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c96">
                           <label class="govuk-label govuk-checkboxes__label" for="c96">Inspection of further education and skills providers</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c97" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c97">
                           <label class="govuk-label govuk-checkboxes__label" for="c97">Performance data and Ofsted reports of further education providers</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c98" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c98">
                           <label class="govuk-label govuk-checkboxes__label" for="c98">Further education provider performance measures</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c99" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c99">
                           <label class="govuk-label govuk-checkboxes__label" for="c99">Student performance in further education</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c100" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c100">
                           <label class="govuk-label govuk-checkboxes__label" for="c100">Further education intervention notices and reports</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c101" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c101">
                           <label class="govuk-label govuk-checkboxes__label" for="c101">Inspection of residential provision in further education colleges</label>
                         </div>
                       </li>
@@ -672,37 +672,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c102" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c102">
                   <label class="govuk-label govuk-checkboxes__label" for="c102">Education of disadvantaged children</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c103" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c103">
                   <label class="govuk-label govuk-checkboxes__label" for="c103">Starting and attending school</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c104" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c104">
                       <label class="govuk-label govuk-checkboxes__label" for="c104">Sending a child to school</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c105" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c105">
                       <label class="govuk-label govuk-checkboxes__label" for="c105">Help with school costs</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c106" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c106">
                       <label class="govuk-label govuk-checkboxes__label" for="c106">Dealing with problems at school</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c107" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c107">
                       <label class="govuk-label govuk-checkboxes__label" for="c107">Home schooling</label>
                     </div>
                   </li>
@@ -710,85 +710,85 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c108" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c108">
                   <label class="govuk-label govuk-checkboxes__label" for="c108">Running and managing a school</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c109" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c109">
                       <label class="govuk-label govuk-checkboxes__label" for="c109">School-to-school support</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c110" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c110">
                       <label class="govuk-label govuk-checkboxes__label" for="c110">Data collection and censuses for schools</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c111" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c111">
                           <label class="govuk-label govuk-checkboxes__label" for="c111">School censuses and school-level annual school censuses (SLASC)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c112" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c112">
                           <label class="govuk-label govuk-checkboxes__label" for="c112">School preference and admission appeals data collection</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c113" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c113">
                           <label class="govuk-label govuk-checkboxes__label" for="c113">Key stage 1 and 2 assessments data collection</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c114" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c114">
                           <label class="govuk-label govuk-checkboxes__label" for="c114">Parental responsibility measures attendance censuses</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c115" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c115">
                           <label class="govuk-label govuk-checkboxes__label" for="c115">School capacity surveys</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c116" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c116">
                           <label class="govuk-label govuk-checkboxes__label" for="c116">Alternative provision censuses</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c117" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c117">
                           <label class="govuk-label govuk-checkboxes__label" for="c117">Special educational needs surveys</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c118" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c118">
                           <label class="govuk-label govuk-checkboxes__label" for="c118">Phonics screening checks</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c119" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c119">
                           <label class="govuk-label govuk-checkboxes__label" for="c119">General hospital school censuses</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c120" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c120">
                           <label class="govuk-label govuk-checkboxes__label" for="c120">School exclusion reviews</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c121" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c121">
                           <label class="govuk-label govuk-checkboxes__label" for="c121">School workforce censuses</label>
                         </div>
                       </li>
@@ -796,25 +796,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c122" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c122">
                       <label class="govuk-label govuk-checkboxes__label" for="c122">School buildings and land</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c123" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c123">
                           <label class="govuk-label govuk-checkboxes__label" for="c123">School places</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c124" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c124">
                           <label class="govuk-label govuk-checkboxes__label" for="c124">School buildings and land transactions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c125" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c125">
                           <label class="govuk-label govuk-checkboxes__label" for="c125">School buildings and land guidelines</label>
                         </div>
                       </li>
@@ -822,43 +822,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c126" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c126">
                       <label class="govuk-label govuk-checkboxes__label" for="c126">School planning</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c127" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c127">
                       <label class="govuk-label govuk-checkboxes__label" for="c127">School governance</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c128" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c128">
                       <label class="govuk-label govuk-checkboxes__label" for="c128">School food, accommodation, transport and uniform</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c129" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c129">
                       <label class="govuk-label govuk-checkboxes__label" for="c129">Setting up or changing the status of a school</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c130" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c130">
                           <label class="govuk-label govuk-checkboxes__label" for="c130">Set up or convert to an academy</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c131" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c131">
                           <label class="govuk-label govuk-checkboxes__label" for="c131">Set up and develop a multi-academy trust (MAT)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c132" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c132">
                           <label class="govuk-label govuk-checkboxes__label" for="c132">Set up a free school</label>
                         </div>
                       </li>
@@ -866,31 +866,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c133" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c133">
                       <label class="govuk-label govuk-checkboxes__label" for="c133">School complaints and whistleblowing</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c134" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c134">
                       <label class="govuk-label govuk-checkboxes__label" for="c134">School trips and extracurricular activity</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c135" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c135">
                       <label class="govuk-label govuk-checkboxes__label" for="c135">School admissions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c136" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c136">
                       <label class="govuk-label govuk-checkboxes__label" for="c136">Careers guidance in schools</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c137" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c137">
                       <label class="govuk-label govuk-checkboxes__label" for="c137">Recruiting and managing non-teaching school staff</label>
                     </div>
                   </li>
@@ -898,31 +898,31 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c138" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c138">
                   <label class="govuk-label govuk-checkboxes__label" for="c138">School and academy financial management and assurance</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c139" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c139">
                       <label class="govuk-label govuk-checkboxes__label" for="c139">Financial management, reporting and assurances for 16 to 19 year olds funding</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c140" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c140">
                       <label class="govuk-label govuk-checkboxes__label" for="c140">School procurement</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c141" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c141">
                       <label class="govuk-label govuk-checkboxes__label" for="c141">Academy and academy trust finance and reporting</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c142" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c142">
                       <label class="govuk-label govuk-checkboxes__label" for="c142">Local authority schools financial reporting and assurance</label>
                     </div>
                   </li>
@@ -930,25 +930,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c143" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c143">
                   <label class="govuk-label govuk-checkboxes__label" for="c143">Funding and finance for students</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c144" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c144">
                       <label class="govuk-label govuk-checkboxes__label" for="c144">Student grants, bursaries and scholarships</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c145" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c145">
                       <label class="govuk-label govuk-checkboxes__label" for="c145">Financial help for students who are parents or carers</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c146" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c146">
                       <label class="govuk-label govuk-checkboxes__label" for="c146">Student loans</label>
                     </div>
                   </li>
@@ -956,43 +956,43 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c147" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c147">
                   <label class="govuk-label govuk-checkboxes__label" for="c147">School curriculum</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c148" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c148">
                       <label class="govuk-label govuk-checkboxes__label" for="c148">Primary curriculum, key stage 2</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c149" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c149">
                           <label class="govuk-label govuk-checkboxes__label" for="c149">Programmes of study (key stage 2)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c150" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c150">
                           <label class="govuk-label govuk-checkboxes__label" for="c150">Science (key stage 2)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c151" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c151">
                           <label class="govuk-label govuk-checkboxes__label" for="c151">English (key stage 2)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c152" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c152">
                           <label class="govuk-label govuk-checkboxes__label" for="c152">Maths (key stage 2)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c153" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c153">
                           <label class="govuk-label govuk-checkboxes__label" for="c153">Tests and assessments (key stage 2)</label>
                         </div>
                       </li>
@@ -1000,37 +1000,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c154" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c154">
                       <label class="govuk-label govuk-checkboxes__label" for="c154">Spiritual, moral, social and cultural development</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c155" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c155">
                       <label class="govuk-label govuk-checkboxes__label" for="c155">Early years curriculum</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c156" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c156">
                       <label class="govuk-label govuk-checkboxes__label" for="c156">Secondary curriculum, key stage 3 and key stage 4 (GCSEs)</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c157" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c157">
                           <label class="govuk-label govuk-checkboxes__label" for="c157">GCSE changes and reforms</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c158" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c158">
                           <label class="govuk-label govuk-checkboxes__label" for="c158">Key stage 3 and 4 exam marking, qualifications and results</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c159" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c159">
                           <label class="govuk-label govuk-checkboxes__label" for="c159">GCSE subject content and requirements</label>
                         </div>
                       </li>
@@ -1038,37 +1038,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c160" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c160">
                       <label class="govuk-label govuk-checkboxes__label" for="c160">Primary curriculum, key stage 1</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c161" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c161">
                           <label class="govuk-label govuk-checkboxes__label" for="c161">Programmes of study (key stage 1)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c162" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c162">
                           <label class="govuk-label govuk-checkboxes__label" for="c162">Science (key stage 1)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c163" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c163">
                           <label class="govuk-label govuk-checkboxes__label" for="c163">Maths (key stage 1)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c164" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c164">
                           <label class="govuk-label govuk-checkboxes__label" for="c164">Tests and assessments (key stage 1)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c165" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c165">
                           <label class="govuk-label govuk-checkboxes__label" for="c165">Phonics</label>
                         </div>
                       </li>
@@ -1076,37 +1076,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c166" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c166">
                       <label class="govuk-label govuk-checkboxes__label" for="c166">Exam regulation and administration</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c167" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c167">
                       <label class="govuk-label govuk-checkboxes__label" for="c167">Personal, social, health and economic education</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c168" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c168">
                       <label class="govuk-label govuk-checkboxes__label" for="c168">Key stage 5 (AS and A Levels)</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c169" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c169">
                           <label class="govuk-label govuk-checkboxes__label" for="c169">AS and A level subject content and requirements</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c170" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c170">
                           <label class="govuk-label govuk-checkboxes__label" for="c170">AS and A level changes and reforms</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c171" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c171">
                           <label class="govuk-label govuk-checkboxes__label" for="c171">Key stage 5 exam marking, qualifications and results</label>
                         </div>
                       </li>
@@ -1116,25 +1116,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c172" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c172">
                   <label class="govuk-label govuk-checkboxes__label" for="c172">Special educational needs and disability (SEND) and high needs</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c173" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c173">
                       <label class="govuk-label govuk-checkboxes__label" for="c173">Funding for special educational needs and disability (SEND)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c174" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c174">
                       <label class="govuk-label govuk-checkboxes__label" for="c174">Support for special educational needs and disability (SEND)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c175" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c175">
                       <label class="govuk-label govuk-checkboxes__label" for="c175">Funding for high needs</label>
                     </div>
                   </li>
@@ -1142,49 +1142,49 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c176" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c176">
                   <label class="govuk-label govuk-checkboxes__label" for="c176">School and academy funding</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c177" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c177">
                       <label class="govuk-label govuk-checkboxes__label" for="c177">Funding for different types of schools and settings</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c178" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c178">
                           <label class="govuk-label govuk-checkboxes__label" for="c178">Special schools funding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c179" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c179">
                           <label class="govuk-label govuk-checkboxes__label" for="c179">Alternative provision funding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c180" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c180">
                           <label class="govuk-label govuk-checkboxes__label" for="c180">Local authority schools funding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c181" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c181">
                           <label class="govuk-label govuk-checkboxes__label" for="c181">Funding for 16 to 19 year olds in schools</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c182" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c182">
                           <label class="govuk-label govuk-checkboxes__label" for="c182">Academy funding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c183" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c183">
                           <label class="govuk-label govuk-checkboxes__label" for="c183">Early years funding</label>
                         </div>
                       </li>
@@ -1192,43 +1192,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c184" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c184">
                       <label class="govuk-label govuk-checkboxes__label" for="c184">Pupil premium and other school premiums</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c185" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c185">
                       <label class="govuk-label govuk-checkboxes__label" for="c185">Free school meals (FSM) funding</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c186" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c186">
                       <label class="govuk-label govuk-checkboxes__label" for="c186">Funding for school buildings and land</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c187" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c187">
                       <label class="govuk-label govuk-checkboxes__label" for="c187">Schools forums</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c188" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c188">
                       <label class="govuk-label govuk-checkboxes__label" for="c188">Initial Teacher Training funding</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c189" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c189">
                           <label class="govuk-label govuk-checkboxes__label" for="c189">School Direct funding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c190" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c190">
                           <label class="govuk-label govuk-checkboxes__label" for="c190">Subject Knowledge Enhancement (SKE) funding</label>
                         </div>
                       </li>
@@ -1236,7 +1236,7 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c191" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c191">
                       <label class="govuk-label govuk-checkboxes__label" for="c191">Funding for school places</label>
                     </div>
                   </li>
@@ -1246,31 +1246,31 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c192" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c192">
               <label class="govuk-label govuk-checkboxes__label" for="c192">Parenting, childcare and children's services</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c193" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c193">
                   <label class="govuk-label govuk-checkboxes__label" for="c193">Divorce, separation and legal issues</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c194" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c194">
                       <label class="govuk-label govuk-checkboxes__label" for="c194">Disagreements about parentage</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c195" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c195">
                       <label class="govuk-label govuk-checkboxes__label" for="c195">Child maintenance</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c196" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c196">
                       <label class="govuk-label govuk-checkboxes__label" for="c196">Child custody</label>
                     </div>
                   </li>
@@ -1278,55 +1278,55 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c197" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c197">
                   <label class="govuk-label govuk-checkboxes__label" for="c197">Childcare and early years</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c198" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c198">
                       <label class="govuk-label govuk-checkboxes__label" for="c198">Local authorities and early years</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c199" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c199">
                       <label class="govuk-label govuk-checkboxes__label" for="c199">Providing childcare</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c200" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c200">
                           <label class="govuk-label govuk-checkboxes__label" for="c200">Recruiting and managing early years staff</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c201" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c201">
                           <label class="govuk-label govuk-checkboxes__label" for="c201">Performance and inspection of childcare providers</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c202" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c202">
                           <label class="govuk-label govuk-checkboxes__label" for="c202">Funding and finance for childcare providers</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c203" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c203">
                           <label class="govuk-label govuk-checkboxes__label" for="c203">Early years curriculum (0 to 5)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c204" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c204">
                           <label class="govuk-label govuk-checkboxes__label" for="c204">Children's centres, childminders, pre-schools and nurseries</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c205" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c205">
                           <label class="govuk-label govuk-checkboxes__label" for="c205">Becoming a childcare provider</label>
                         </div>
                       </li>
@@ -1334,25 +1334,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c206" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c206">
                       <label class="govuk-label govuk-checkboxes__label" for="c206">Finding childcare</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c207" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c207">
                       <label class="govuk-label govuk-checkboxes__label" for="c207">Data collection for early years and childcare</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c208" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c208">
                           <label class="govuk-label govuk-checkboxes__label" for="c208">Early years census</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c209" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c209">
                           <label class="govuk-label govuk-checkboxes__label" for="c209">Early years foundation stage profile return</label>
                         </div>
                       </li>
@@ -1362,49 +1362,49 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c210" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c210">
                   <label class="govuk-label govuk-checkboxes__label" for="c210">Financial help if you have children</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c211" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c211">
                       <label class="govuk-label govuk-checkboxes__label" for="c211">Child benefit</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c212" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c212">
                       <label class="govuk-label govuk-checkboxes__label" for="c212">Financial help if you have a disabled child</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c213" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c213">
                       <label class="govuk-label govuk-checkboxes__label" for="c213">Tax credits if you have children</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c214" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c214">
                       <label class="govuk-label govuk-checkboxes__label" for="c214">Savings accounts for children</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c215" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c215">
                       <label class="govuk-label govuk-checkboxes__label" for="c215">Financial support for childcare</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c216" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c216">
                       <label class="govuk-label govuk-checkboxes__label" for="c216">Financial help when having a baby</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c217" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c217">
                       <label class="govuk-label govuk-checkboxes__label" for="c217">Financial help if you're a student with children</label>
                     </div>
                   </li>
@@ -1412,37 +1412,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c218" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c218">
                   <label class="govuk-label govuk-checkboxes__label" for="c218">Adoption, fostering and surrogacy</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c219" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c219">
                       <label class="govuk-label govuk-checkboxes__label" for="c219">Intercountry adoption</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c220" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c220">
                       <label class="govuk-label govuk-checkboxes__label" for="c220">Adoption</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c221" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c221">
                       <label class="govuk-label govuk-checkboxes__label" for="c221">Surrogacy</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c222" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c222">
                       <label class="govuk-label govuk-checkboxes__label" for="c222">Special guardianship</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c223" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c223">
                       <label class="govuk-label govuk-checkboxes__label" for="c223">Fostering</label>
                     </div>
                   </li>
@@ -1450,37 +1450,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c224" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c224">
                   <label class="govuk-label govuk-checkboxes__label" for="c224">Children's health and welfare</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c225" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c225">
                       <label class="govuk-label govuk-checkboxes__label" for="c225">Support for children with special educational needs and disabilities (SEND)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c226" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c226">
                       <label class="govuk-label govuk-checkboxes__label" for="c226">Mental health of children and young people</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c227" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c227">
                       <label class="govuk-label govuk-checkboxes__label" for="c227">Help for children with a long-term illness or disability</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c228" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c228">
                       <label class="govuk-label govuk-checkboxes__label" for="c228">Children's rights</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c229" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c229">
                       <label class="govuk-label govuk-checkboxes__label" for="c229">Child poverty</label>
                     </div>
                   </li>
@@ -1488,25 +1488,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c230" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c230">
                   <label class="govuk-label govuk-checkboxes__label" for="c230">Youth employment and social issues</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c231" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c231">
                   <label class="govuk-label govuk-checkboxes__label" for="c231">Pregnancy and birth</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c232" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c232">
                       <label class="govuk-label govuk-checkboxes__label" for="c232">Working and time off when you're having a baby</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c233" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c233">
                       <label class="govuk-label govuk-checkboxes__label" for="c233">Register the birth of a child</label>
                     </div>
                   </li>
@@ -1514,49 +1514,49 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c234" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c234">
                   <label class="govuk-label govuk-checkboxes__label" for="c234">Safeguarding and social care for children</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c235" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c235">
                       <label class="govuk-label govuk-checkboxes__label" for="c235">Child and family social work</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c236" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c236">
                       <label class="govuk-label govuk-checkboxes__label" for="c236">Safeguarding and child protection</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c237" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c237">
                           <label class="govuk-label govuk-checkboxes__label" for="c237">Data collection for safeguarding and child protection</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c238" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c238">
                           <label class="govuk-label govuk-checkboxes__label" for="c238">Preventing neglect, abuse and exploitation</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c239" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c239">
                           <label class="govuk-label govuk-checkboxes__label" for="c239">Serious case reviews</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c240" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c240">
                           <label class="govuk-label govuk-checkboxes__label" for="c240">Refugee, runaway and homeless children</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c241" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c241">
                           <label class="govuk-label govuk-checkboxes__label" for="c241">Child abduction and cross-border child protection</label>
                         </div>
                       </li>
@@ -1564,31 +1564,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c242" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c242">
                       <label class="govuk-label govuk-checkboxes__label" for="c242">Looked-after children and children in care</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c243" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c243">
                           <label class="govuk-label govuk-checkboxes__label" for="c243">Data collection for looked-after children</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c244" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c244">
                           <label class="govuk-label govuk-checkboxes__label" for="c244">Health, wellbeing and education of looked-after children</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c245" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c245">
                           <label class="govuk-label govuk-checkboxes__label" for="c245">Children's homes and other accommodation</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c246" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c246">
                           <label class="govuk-label govuk-checkboxes__label" for="c246">Children and young people leaving care</label>
                         </div>
                       </li>
@@ -1596,49 +1596,49 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c247" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c247">
                       <label class="govuk-label govuk-checkboxes__label" for="c247">Children's social care providers</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c248" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c248">
                           <label class="govuk-label govuk-checkboxes__label" for="c248">Becoming a children's social care provider</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c249" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c249">
                           <label class="govuk-label govuk-checkboxes__label" for="c249">Social care provider complaints</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c250" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c250">
                           <label class="govuk-label govuk-checkboxes__label" for="c250">Inspection of children's social care providers</label>
                         </div>
                         <ul class="govuk-list">
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c251" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c251">
                               <label class="govuk-label govuk-checkboxes__label" for="c251">Inspections of local authority children's services</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c252" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c252">
                               <label class="govuk-label govuk-checkboxes__label" for="c252">Inspections of fostering and adoption agencies</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c253" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c253">
                               <label class="govuk-label govuk-checkboxes__label" for="c253">Incidents, concerns and feedback about children's social care providers</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c254" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c254">
                               <label class="govuk-label govuk-checkboxes__label" for="c254">Children's homes and other residential care inspections</label>
                             </div>
                           </li>
@@ -1652,49 +1652,49 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c255" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c255">
               <label class="govuk-label govuk-checkboxes__label" for="c255">Corporate information</label>
             </div>
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c256" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c256">
               <label class="govuk-label govuk-checkboxes__label" for="c256">Transport</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c257" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c257">
                   <label class="govuk-label govuk-checkboxes__label" for="c257">Transport modelling and appraisal</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c258" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c258">
                   <label class="govuk-label govuk-checkboxes__label" for="c258">Transport accessibility and mobility</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c259" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c259">
                       <label class="govuk-label govuk-checkboxes__label" for="c259">Help on public transport</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c260" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c260">
                       <label class="govuk-label govuk-checkboxes__label" for="c260">Blue badges</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c261" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c261">
                       <label class="govuk-label govuk-checkboxes__label" for="c261">Mobility scooters and wheelchairs</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c262" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c262">
                       <label class="govuk-label govuk-checkboxes__label" for="c262">Taxi and private hire accessibility</label>
                     </div>
                   </li>
@@ -1702,67 +1702,67 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c263" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c263">
                   <label class="govuk-label govuk-checkboxes__label" for="c263">Rail</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c264" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c264">
                       <label class="govuk-label govuk-checkboxes__label" for="c264">Rail accidents and serious incidents</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c265" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c265">
                       <label class="govuk-label govuk-checkboxes__label" for="c265">Rolling stock (passenger trains)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c266" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c266">
                       <label class="govuk-label govuk-checkboxes__label" for="c266">Community rail</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c267" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c267">
                       <label class="govuk-label govuk-checkboxes__label" for="c267">Rail network and the environment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c268" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c268">
                       <label class="govuk-label govuk-checkboxes__label" for="c268">HS2</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c269" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c269">
                           <label class="govuk-label govuk-checkboxes__label" for="c269">HS2 planning</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c270" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c270">
                           <label class="govuk-label govuk-checkboxes__label" for="c270">HS2 Phase One</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c271" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c271">
                           <label class="govuk-label govuk-checkboxes__label" for="c271">HS2 Phase Two</label>
                         </div>
                         <ul class="govuk-list">
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c272" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c272">
                               <label class="govuk-label govuk-checkboxes__label" for="c272">HS2 Phase 2b</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c273" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c273">
                               <label class="govuk-label govuk-checkboxes__label" for="c273">HS2 Phase 2a</label>
                             </div>
                           </li>
@@ -1770,73 +1770,73 @@
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c274" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c274">
                           <label class="govuk-label govuk-checkboxes__label" for="c274">HS2 costs</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c275" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c275">
                           <label class="govuk-label govuk-checkboxes__label" for="c275">HS2 additional provisions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c276" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c276">
                           <label class="govuk-label govuk-checkboxes__label" for="c276">HS2 design</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c277" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c277">
                           <label class="govuk-label govuk-checkboxes__label" for="c277">HS2 legislation</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c278" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c278">
                           <label class="govuk-label govuk-checkboxes__label" for="c278">HS2 stakeholder and community engagement</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c279" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c279">
                           <label class="govuk-label govuk-checkboxes__label" for="c279">HS2 stations</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c280" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c280">
                           <label class="govuk-label govuk-checkboxes__label" for="c280">HS2 supply chain</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c281" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c281">
                           <label class="govuk-label govuk-checkboxes__label" for="c281">HS2 construction and engineering</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c282" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c282">
                           <label class="govuk-label govuk-checkboxes__label" for="c282">HS2 property</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c283" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c283">
                           <label class="govuk-label govuk-checkboxes__label" for="c283">HS2 business case</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c284" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c284">
                           <label class="govuk-label govuk-checkboxes__label" for="c284">HS2 corporate</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c285" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c285">
                           <label class="govuk-label govuk-checkboxes__label" for="c285">HS2 and the environment</label>
                         </div>
                       </li>
@@ -1844,19 +1844,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c286" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c286">
                       <label class="govuk-label govuk-checkboxes__label" for="c286">Rail franchising</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c287" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c287">
                           <label class="govuk-label govuk-checkboxes__label" for="c287">Rail franchise public register</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c288" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c288">
                           <label class="govuk-label govuk-checkboxes__label" for="c288">Rail franchise procurement</label>
                         </div>
                       </li>
@@ -1864,55 +1864,55 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c289" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c289">
                       <label class="govuk-label govuk-checkboxes__label" for="c289">Rail passenger experience</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c290" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c290">
                       <label class="govuk-label govuk-checkboxes__label" for="c290">Rail stations</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c291" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c291">
                       <label class="govuk-label govuk-checkboxes__label" for="c291">Rail accessibility</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c292" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c292">
                       <label class="govuk-label govuk-checkboxes__label" for="c292">Rail safety and security</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c293" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c293">
                       <label class="govuk-label govuk-checkboxes__label" for="c293">Rail infrastructure</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c294" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c294">
                       <label class="govuk-label govuk-checkboxes__label" for="c294">Crossrail</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c295" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c295">
                       <label class="govuk-label govuk-checkboxes__label" for="c295">Rail ticketing and fares</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c296" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c296">
                       <label class="govuk-label govuk-checkboxes__label" for="c296">Rail interoperability</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c297" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c297">
                       <label class="govuk-label govuk-checkboxes__label" for="c297">Rail network</label>
                     </div>
                   </li>
@@ -1920,55 +1920,55 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c298" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c298">
                   <label class="govuk-label govuk-checkboxes__label" for="c298">Transport planning</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c299" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c299">
                   <label class="govuk-label govuk-checkboxes__label" for="c299">Transport security</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c300" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c300">
                   <label class="govuk-label govuk-checkboxes__label" for="c300">Corporate and operational information (transport)</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c301" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c301">
                   <label class="govuk-label govuk-checkboxes__label" for="c301">Driving and road transport</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c302" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c302">
                       <label class="govuk-label govuk-checkboxes__label" for="c302">Road traffic</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c303" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c303">
                       <label class="govuk-label govuk-checkboxes__label" for="c303">Road transport and the environment</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c304" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c304">
                           <label class="govuk-label govuk-checkboxes__label" for="c304">Road transport emissions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c305" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c305">
                           <label class="govuk-label govuk-checkboxes__label" for="c305">Low emission and electric vehicles</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c306" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c306">
                           <label class="govuk-label govuk-checkboxes__label" for="c306">Renewable fuels</label>
                         </div>
                       </li>
@@ -1976,43 +1976,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c307" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c307">
                       <label class="govuk-label govuk-checkboxes__label" for="c307">Transport businesses and vehicle operator licences</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c308" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c308">
                           <label class="govuk-label govuk-checkboxes__label" for="c308">Driver CPC training centres</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c309" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c309">
                           <label class="govuk-label govuk-checkboxes__label" for="c309">Employing drivers</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c310" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c310">
                           <label class="govuk-label govuk-checkboxes__label" for="c310">Vehicle operator licences</label>
                         </div>
                         <ul class="govuk-list">
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c311" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c311">
                               <label class="govuk-label govuk-checkboxes__label" for="c311">HGV and goods carriage vehicle licencing</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c312" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c312">
                               <label class="govuk-label govuk-checkboxes__label" for="c312">Public service vehicles licencing</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c313" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c313">
                               <label class="govuk-label govuk-checkboxes__label" for="c313">Taxi and private hire vehicle licencing</label>
                             </div>
                           </li>
@@ -2020,7 +2020,7 @@
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c314" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c314">
                           <label class="govuk-label govuk-checkboxes__label" for="c314">Fleet management</label>
                         </div>
                       </li>
@@ -2028,25 +2028,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c315" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c315">
                       <label class="govuk-label govuk-checkboxes__label" for="c315">Professional driving of lorries, buses and coaches</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c316" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c316">
                           <label class="govuk-label govuk-checkboxes__label" for="c316">Driver CPC training</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c317" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c317">
                           <label class="govuk-label govuk-checkboxes__label" for="c317">Tachographs</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c318" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c318">
                           <label class="govuk-label govuk-checkboxes__label" for="c318">EU and international driving rules</label>
                         </div>
                       </li>
@@ -2054,31 +2054,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c319" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c319">
                       <label class="govuk-label govuk-checkboxes__label" for="c319">Driving instruction and driving lessons</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c320" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c320">
                           <label class="govuk-label govuk-checkboxes__label" for="c320">Driving instructor registration and renewals</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c321" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c321">
                           <label class="govuk-label govuk-checkboxes__label" for="c321">Professional development for driving and motorcycle instructors</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c322" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c322">
                           <label class="govuk-label govuk-checkboxes__label" for="c322">Driving, motorcycle and LGV instructor qualification process</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c323" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c323">
                           <label class="govuk-label govuk-checkboxes__label" for="c323">Driving examination</label>
                         </div>
                       </li>
@@ -2086,61 +2086,61 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c324" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c324">
                       <label class="govuk-label govuk-checkboxes__label" for="c324">Road safety, driving rules and penalties</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c325" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c325">
                           <label class="govuk-label govuk-checkboxes__label" for="c325">Drink and drug driving</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c326" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c326">
                           <label class="govuk-label govuk-checkboxes__label" for="c326">Road accidents and serious accidents</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c327" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c327">
                           <label class="govuk-label govuk-checkboxes__label" for="c327">Drivers' hours</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c328" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c328">
                           <label class="govuk-label govuk-checkboxes__label" for="c328">Towing</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c329" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c329">
                           <label class="govuk-label govuk-checkboxes__label" for="c329">Penalty points, fines and driving bans</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c330" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c330">
                           <label class="govuk-label govuk-checkboxes__label" for="c330">Speeding</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c331" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c331">
                           <label class="govuk-label govuk-checkboxes__label" for="c331">Seat belts</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c332" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c332">
                           <label class="govuk-label govuk-checkboxes__label" for="c332">Driving and mobile phones</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c333" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c333">
                           <label class="govuk-label govuk-checkboxes__label" for="c333">Driving and medical conditions</label>
                         </div>
                       </li>
@@ -2148,43 +2148,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c334" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c334">
                       <label class="govuk-label govuk-checkboxes__label" for="c334">Driving licences</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c335" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c335">
                           <label class="govuk-label govuk-checkboxes__label" for="c335">Driving licence applications and renewals</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c336" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c336">
                           <label class="govuk-label govuk-checkboxes__label" for="c336">Driving abroad</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c337" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c337">
                           <label class="govuk-label govuk-checkboxes__label" for="c337">Driving licence categories</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c338" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c338">
                           <label class="govuk-label govuk-checkboxes__label" for="c338">Foreign driving licences</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c339" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c339">
                           <label class="govuk-label govuk-checkboxes__label" for="c339">Driving licences and medical conditions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c340" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c340">
                           <label class="govuk-label govuk-checkboxes__label" for="c340">Personal driving licence information</label>
                         </div>
                       </li>
@@ -2192,37 +2192,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c341" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c341">
                       <label class="govuk-label govuk-checkboxes__label" for="c341">Driving and motorcycle tests</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c342" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c342">
                           <label class="govuk-label govuk-checkboxes__label" for="c342">Car driving tests</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c343" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c343">
                           <label class="govuk-label govuk-checkboxes__label" for="c343">Motorcycle and moped tests</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c344" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c344">
                           <label class="govuk-label govuk-checkboxes__label" for="c344">Lorry, bus, coach and specialist vehicle driving tests</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c345" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c345">
                           <label class="govuk-label govuk-checkboxes__label" for="c345">Theory tests</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c346" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c346">
                           <label class="govuk-label govuk-checkboxes__label" for="c346">Motorcycle training</label>
                         </div>
                       </li>
@@ -2230,61 +2230,61 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c347" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c347">
                       <label class="govuk-label govuk-checkboxes__label" for="c347">Vehicle ownership, approval and standards</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c348" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c348">
                           <label class="govuk-label govuk-checkboxes__label" for="c348">Buying, selling, registering and scrapping a vehicle</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c349" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c349">
                           <label class="govuk-label govuk-checkboxes__label" for="c349">PSV standards and checks</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c350" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c350">
                           <label class="govuk-label govuk-checkboxes__label" for="c350">Vehicle registration, log books and number plates</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c351" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c351">
                           <label class="govuk-label govuk-checkboxes__label" for="c351">HGV standards and checks</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c352" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c352">
                           <label class="govuk-label govuk-checkboxes__label" for="c352">Vehicle manufacturing and modification</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c353" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c353">
                           <label class="govuk-label govuk-checkboxes__label" for="c353">Vehicle recalls</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c354" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c354">
                           <label class="govuk-label govuk-checkboxes__label" for="c354">MOTs</label>
                         </div>
                         <ul class="govuk-list">
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c355" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c355">
                               <label class="govuk-label govuk-checkboxes__label" for="c355">Car, motorcycle and van MOT tests</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c356" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c356">
                               <label class="govuk-label govuk-checkboxes__label" for="c356">Lorry, bus and trailer MOT tests</label>
                             </div>
                           </li>
@@ -2292,25 +2292,25 @@
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c357" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c357">
                           <label class="govuk-label govuk-checkboxes__label" for="c357">Vehicle insurance</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c358" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c358">
                           <label class="govuk-label govuk-checkboxes__label" for="c358">Vehicle tax</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c359" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c359">
                           <label class="govuk-label govuk-checkboxes__label" for="c359">Vehicle import and export</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c360" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c360">
                           <label class="govuk-label govuk-checkboxes__label" for="c360">Driver and vehicle record</label>
                         </div>
                       </li>
@@ -2318,19 +2318,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c361" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c361">
                       <label class="govuk-label govuk-checkboxes__label" for="c361">Autonomous road vehicles</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c362" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c362">
                       <label class="govuk-label govuk-checkboxes__label" for="c362">Cycling and walking</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c363" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c363">
                       <label class="govuk-label govuk-checkboxes__label" for="c363">Vans and minibuses</label>
                     </div>
                   </li>
@@ -2338,31 +2338,31 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c364" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c364">
                   <label class="govuk-label govuk-checkboxes__label" for="c364">Freight and cargo</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c365" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c365">
                       <label class="govuk-label govuk-checkboxes__label" for="c365">Vessel cargo</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c366" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c366">
                       <label class="govuk-label govuk-checkboxes__label" for="c366">Transporting dangerous goods</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c367" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c367">
                           <label class="govuk-label govuk-checkboxes__label" for="c367">Safe transport of dangerous goods by sea</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c368" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c368">
                           <label class="govuk-label govuk-checkboxes__label" for="c368">Safe transport of dangerous goods by road and rail</label>
                         </div>
                       </li>
@@ -2370,13 +2370,13 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c369" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c369">
                       <label class="govuk-label govuk-checkboxes__label" for="c369">Rail freight and cargo</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c370" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c370">
                       <label class="govuk-label govuk-checkboxes__label" for="c370">Road freight</label>
                     </div>
                   </li>
@@ -2384,49 +2384,49 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c371" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c371">
                   <label class="govuk-label govuk-checkboxes__label" for="c371">Road infrastructure</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c372" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c372">
                       <label class="govuk-label govuk-checkboxes__label" for="c372">Road tolls and charges</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c373" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c373">
                       <label class="govuk-label govuk-checkboxes__label" for="c373">Road improvement and investment</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c374" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c374">
                           <label class="govuk-label govuk-checkboxes__label" for="c374">Road resurfacing</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c375" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c375">
                           <label class="govuk-label govuk-checkboxes__label" for="c375">Making roads safer</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c376" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c376">
                           <label class="govuk-label govuk-checkboxes__label" for="c376">Motorways</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c377" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c377">
                           <label class="govuk-label govuk-checkboxes__label" for="c377">Local roads</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c378" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c378">
                           <label class="govuk-label govuk-checkboxes__label" for="c378">Major roads</label>
                         </div>
                       </li>
@@ -2434,37 +2434,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c379" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c379">
                       <label class="govuk-label govuk-checkboxes__label" for="c379">Road works and street works</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c380" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c380">
                           <label class="govuk-label govuk-checkboxes__label" for="c380">Property affected by roadworks and street works</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c381" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c381">
                           <label class="govuk-label govuk-checkboxes__label" for="c381">Overnight works</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c382" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c382">
                           <label class="govuk-label govuk-checkboxes__label" for="c382">Road closures</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c383" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c383">
                           <label class="govuk-label govuk-checkboxes__label" for="c383">Planned roadworks</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c384" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c384">
                           <label class="govuk-label govuk-checkboxes__label" for="c384">Weekend closures</label>
                         </div>
                       </li>
@@ -2472,49 +2472,49 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c385" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c385">
                       <label class="govuk-label govuk-checkboxes__label" for="c385">Speed limits and traffic cameras</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c386" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c386">
                       <label class="govuk-label govuk-checkboxes__label" for="c386">Traffic signs, signals and markings</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c387" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c387">
                       <label class="govuk-label govuk-checkboxes__label" for="c387">Parking</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c388" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c388">
                       <label class="govuk-label govuk-checkboxes__label" for="c388">Smart motorways</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c389" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c389">
                       <label class="govuk-label govuk-checkboxes__label" for="c389">Advice for drivers</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c390" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c390">
                       <label class="govuk-label govuk-checkboxes__label" for="c390">Roads and the environment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c391" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c391">
                       <label class="govuk-label govuk-checkboxes__label" for="c391">Animals on roads</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c392" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c392">
                       <label class="govuk-label govuk-checkboxes__label" for="c392">Road maintenance</label>
                     </div>
                   </li>
@@ -2522,43 +2522,43 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c393" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c393">
                   <label class="govuk-label govuk-checkboxes__label" for="c393">Careers in transport</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c394" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c394">
                   <label class="govuk-label govuk-checkboxes__label" for="c394">Maritime and shipping</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c395" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c395">
                       <label class="govuk-label govuk-checkboxes__label" for="c395">Maritime accidents and serious incidents</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c396" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c396">
                       <label class="govuk-label govuk-checkboxes__label" for="c396">Vessel registration and design</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c397" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c397">
                           <label class="govuk-label govuk-checkboxes__label" for="c397">Ship equipment</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c398" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c398">
                           <label class="govuk-label govuk-checkboxes__label" for="c398">Vessel registration</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c399" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c399">
                           <label class="govuk-label govuk-checkboxes__label" for="c399">Vessel design</label>
                         </div>
                       </li>
@@ -2566,25 +2566,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c400" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c400">
                       <label class="govuk-label govuk-checkboxes__label" for="c400">Ports, harbours and offshore installations</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c401" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c401">
                       <label class="govuk-label govuk-checkboxes__label" for="c401">Maritime safety</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c402" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c402">
                           <label class="govuk-label govuk-checkboxes__label" for="c402">Life saving appliances (LSA)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c403" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c403">
                           <label class="govuk-label govuk-checkboxes__label" for="c403">Safe and compliant operation of vessels</label>
                         </div>
                       </li>
@@ -2592,49 +2592,49 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c404" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c404">
                       <label class="govuk-label govuk-checkboxes__label" for="c404">Maritime and the environment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c405" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c405">
                       <label class="govuk-label govuk-checkboxes__label" for="c405">Maritime navigation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c406" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c406">
                       <label class="govuk-label govuk-checkboxes__label" for="c406">Coastguard search and rescue</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c407" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c407">
                       <label class="govuk-label govuk-checkboxes__label" for="c407">Wrecks</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c408" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c408">
                       <label class="govuk-label govuk-checkboxes__label" for="c408">Seafarer management, training and certification</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c409" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c409">
                           <label class="govuk-label govuk-checkboxes__label" for="c409">Ship crew health and safety</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c410" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c410">
                           <label class="govuk-label govuk-checkboxes__label" for="c410">Ship crew training and certification</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c411" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c411">
                           <label class="govuk-label govuk-checkboxes__label" for="c411">Employment of seafarers</label>
                         </div>
                       </li>
@@ -2642,43 +2642,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c412" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c412">
                       <label class="govuk-label govuk-checkboxes__label" for="c412">Maritime enforcement and prosecution</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c413" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c413">
                       <label class="govuk-label govuk-checkboxes__label" for="c413">Fishing</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c414" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c414">
                       <label class="govuk-label govuk-checkboxes__label" for="c414">Vessel surveys and inspection</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c415" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c415">
                       <label class="govuk-label govuk-checkboxes__label" for="c415">Maritime security</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c416" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c416">
                       <label class="govuk-label govuk-checkboxes__label" for="c416">Waterways (maritime)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c417" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c417">
                       <label class="govuk-label govuk-checkboxes__label" for="c417">Maritime passenger rights</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c418" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c418">
                       <label class="govuk-label govuk-checkboxes__label" for="c418">UK sea passengers</label>
                     </div>
                   </li>
@@ -2686,61 +2686,61 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c419" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c419">
                   <label class="govuk-label govuk-checkboxes__label" for="c419">Aviation</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c420" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c420">
                       <label class="govuk-label govuk-checkboxes__label" for="c420">Air accidents and serious incidents</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c421" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c421">
                       <label class="govuk-label govuk-checkboxes__label" for="c421">General aviation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c422" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c422">
                       <label class="govuk-label govuk-checkboxes__label" for="c422">Air navigation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c423" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c423">
                       <label class="govuk-label govuk-checkboxes__label" for="c423">Airport capacity and expansion</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c424" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c424">
                       <label class="govuk-label govuk-checkboxes__label" for="c424">Aviation safety and security</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c425" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c425">
                       <label class="govuk-label govuk-checkboxes__label" for="c425">Aviation and the environment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c426" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c426">
                       <label class="govuk-label govuk-checkboxes__label" for="c426">New aviation technology</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c427" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c427">
                           <label class="govuk-label govuk-checkboxes__label" for="c427">Spaceflight</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c428" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c428">
                           <label class="govuk-label govuk-checkboxes__label" for="c428">Drones</label>
                         </div>
                       </li>
@@ -2748,37 +2748,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c429" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c429">
                       <label class="govuk-label govuk-checkboxes__label" for="c429">Night flights</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c430" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c430">
                       <label class="govuk-label govuk-checkboxes__label" for="c430">Aviation passenger experience</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c431" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c431">
                       <label class="govuk-label govuk-checkboxes__label" for="c431">Surface access to airports</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c432" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c432">
                       <label class="govuk-label govuk-checkboxes__label" for="c432">Aviation and Europe</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c433" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c433">
                       <label class="govuk-label govuk-checkboxes__label" for="c433">Air routes</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c434" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c434">
                       <label class="govuk-label govuk-checkboxes__label" for="c434">Air passenger duty</label>
                     </div>
                   </li>
@@ -2786,61 +2786,61 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c435" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c435">
                   <label class="govuk-label govuk-checkboxes__label" for="c435">Local transport</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c436" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c436">
                       <label class="govuk-label govuk-checkboxes__label" for="c436">Tube</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c437" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c437">
                       <label class="govuk-label govuk-checkboxes__label" for="c437">Local transport funding</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c438" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c438">
                       <label class="govuk-label govuk-checkboxes__label" for="c438">Buses</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c439" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c439">
                           <label class="govuk-label govuk-checkboxes__label" for="c439">Bus services, routes and timetables</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c440" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c440">
                           <label class="govuk-label govuk-checkboxes__label" for="c440">Bus accessibility</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c441" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c441">
                           <label class="govuk-label govuk-checkboxes__label" for="c441">Bus passenger experience</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c442" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c442">
                           <label class="govuk-label govuk-checkboxes__label" for="c442">Improvements to buses</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c443" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c443">
                           <label class="govuk-label govuk-checkboxes__label" for="c443">Bus operators</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c444" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c444">
                           <label class="govuk-label govuk-checkboxes__label" for="c444">Buses and the environment</label>
                         </div>
                       </li>
@@ -2848,19 +2848,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c445" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c445">
                       <label class="govuk-label govuk-checkboxes__label" for="c445">Inland waterways</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c446" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c446">
                       <label class="govuk-label govuk-checkboxes__label" for="c446">Light rail and trams</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c447" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c447">
                       <label class="govuk-label govuk-checkboxes__label" for="c447">Travel passes and concessions</label>
                     </div>
                   </li>
@@ -2870,55 +2870,55 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c448" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c448">
               <label class="govuk-label govuk-checkboxes__label" for="c448">Environment</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c449" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c449">
                   <label class="govuk-label govuk-checkboxes__label" for="c449">Environmental permits</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c450" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c450">
                   <label class="govuk-label govuk-checkboxes__label" for="c450">Water industry</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c451" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c451">
                       <label class="govuk-label govuk-checkboxes__label" for="c451">Water and sewerage services</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c452" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c452">
                       <label class="govuk-label govuk-checkboxes__label" for="c452">Drought and water availability</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c453" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c453">
                       <label class="govuk-label govuk-checkboxes__label" for="c453">Water quality</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c454" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c454">
                       <label class="govuk-label govuk-checkboxes__label" for="c454">Impound (store) water</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c455" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c455">
                       <label class="govuk-label govuk-checkboxes__label" for="c455">Discharge water</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c456" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c456">
                       <label class="govuk-label govuk-checkboxes__label" for="c456">Abstract (take) water</label>
                     </div>
                   </li>
@@ -2926,67 +2926,67 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c457" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c457">
                   <label class="govuk-label govuk-checkboxes__label" for="c457">Climate change and energy</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c458" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c458">
                       <label class="govuk-label govuk-checkboxes__label" for="c458">Hydropower</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c459" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c459">
                       <label class="govuk-label govuk-checkboxes__label" for="c459">Climate change adaptation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c460" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c460">
                       <label class="govuk-label govuk-checkboxes__label" for="c460">Climate change international action</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c461" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c461">
                       <label class="govuk-label govuk-checkboxes__label" for="c461">Greenhouse gas emissions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c462" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c462">
                       <label class="govuk-label govuk-checkboxes__label" for="c462">Energy and climate change: evidence and analysis</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c463" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c463">
                       <label class="govuk-label govuk-checkboxes__label" for="c463">Low carbon technologies</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c464" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c464">
                       <label class="govuk-label govuk-checkboxes__label" for="c464">Energy security</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c465" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c465">
                       <label class="govuk-label govuk-checkboxes__label" for="c465">Energy infrastructure</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c466" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c466">
                       <label class="govuk-label govuk-checkboxes__label" for="c466">Energy efficiency</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c467" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c467">
                       <label class="govuk-label govuk-checkboxes__label" for="c467">Emissions and emissions trading</label>
                     </div>
                   </li>
@@ -2994,67 +2994,67 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c468" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c468">
                   <label class="govuk-label govuk-checkboxes__label" for="c468">Rural and countryside</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c469" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c469">
                       <label class="govuk-label govuk-checkboxes__label" for="c469">Rural development and land management</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c470" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c470">
                           <label class="govuk-label govuk-checkboxes__label" for="c470">Rural economy and community</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c471" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c471">
                           <label class="govuk-label govuk-checkboxes__label" for="c471">Economic growth in rural areas</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c472" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c472">
                           <label class="govuk-label govuk-checkboxes__label" for="c472">Contaminated land</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c473" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c473">
                           <label class="govuk-label govuk-checkboxes__label" for="c473">Weeds and invasive, non-native plants</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c474" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c474">
                           <label class="govuk-label govuk-checkboxes__label" for="c474">Pollution</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c475" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c475">
                           <label class="govuk-label govuk-checkboxes__label" for="c475">Protected sites</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c476" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c476">
                           <label class="govuk-label govuk-checkboxes__label" for="c476">Farming</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c477" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c477">
                           <label class="govuk-label govuk-checkboxes__label" for="c477">Hedgerows</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c478" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c478">
                           <label class="govuk-label govuk-checkboxes__label" for="c478">Commons and greens</label>
                         </div>
                       </li>
@@ -3062,25 +3062,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c479" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c479">
                       <label class="govuk-label govuk-checkboxes__label" for="c479">Forests and woodland</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c480" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c480">
                       <label class="govuk-label govuk-checkboxes__label" for="c480">Countryside</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c481" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c481">
                           <label class="govuk-label govuk-checkboxes__label" for="c481">Parks, trails and nature reserves</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c482" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c482">
                           <label class="govuk-label govuk-checkboxes__label" for="c482">Access to the countryside</label>
                         </div>
                       </li>
@@ -3088,7 +3088,7 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c483" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c483">
                       <label class="govuk-label govuk-checkboxes__label" for="c483">Boats and waterways</label>
                     </div>
                   </li>
@@ -3096,73 +3096,73 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c484" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c484">
                   <label class="govuk-label govuk-checkboxes__label" for="c484">Pollution and environmental quality</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c485" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c485">
                   <label class="govuk-label govuk-checkboxes__label" for="c485">River maintenance, flooding and coastal erosion</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c486" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c486">
                   <label class="govuk-label govuk-checkboxes__label" for="c486">Wildlife, animals, biodiversity and ecosystems</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c487" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c487">
                       <label class="govuk-label govuk-checkboxes__label" for="c487">Animal welfare</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c488" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c488">
                       <label class="govuk-label govuk-checkboxes__label" for="c488">Pets</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c489" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c489">
                       <label class="govuk-label govuk-checkboxes__label" for="c489">Wildlife and habitat conservation</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c490" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c490">
                           <label class="govuk-label govuk-checkboxes__label" for="c490">Plants</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c491" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c491">
                           <label class="govuk-label govuk-checkboxes__label" for="c491">Reptiles and amphibians</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c492" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c492">
                           <label class="govuk-label govuk-checkboxes__label" for="c492">Mammals</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c493" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c493">
                           <label class="govuk-label govuk-checkboxes__label" for="c493">Fish and shellfish</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c494" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c494">
                           <label class="govuk-label govuk-checkboxes__label" for="c494">Invertebrates</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c495" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c495">
                           <label class="govuk-label govuk-checkboxes__label" for="c495">Birds</label>
                         </div>
                       </li>
@@ -3170,25 +3170,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c496" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c496">
                       <label class="govuk-label govuk-checkboxes__label" for="c496">Protected sites and species</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c497" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c497">
                           <label class="govuk-label govuk-checkboxes__label" for="c497">Land species</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c498" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c498">
                           <label class="govuk-label govuk-checkboxes__label" for="c498">Land sites</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c499" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c499">
                           <label class="govuk-label govuk-checkboxes__label" for="c499">Marine sites and species</label>
                         </div>
                       </li>
@@ -3196,19 +3196,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c500" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c500">
                       <label class="govuk-label govuk-checkboxes__label" for="c500">Animal and plant health</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c501" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c501">
                       <label class="govuk-label govuk-checkboxes__label" for="c501">Wildlife and animal welfare</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c502" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c502">
                       <label class="govuk-label govuk-checkboxes__label" for="c502">Biodiversity and ecosystems</label>
                     </div>
                   </li>
@@ -3216,61 +3216,61 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c503" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c503">
                   <label class="govuk-label govuk-checkboxes__label" for="c503">Commercial fishing, fisheries and vessels</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c504" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c504">
                       <label class="govuk-label govuk-checkboxes__label" for="c504">Marine fisheries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c505" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c505">
                       <label class="govuk-label govuk-checkboxes__label" for="c505">Freshwater fisheries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c506" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c506">
                       <label class="govuk-label govuk-checkboxes__label" for="c506">Fisheries funding</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c507" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c507">
                       <label class="govuk-label govuk-checkboxes__label" for="c507">Fishing vessels</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c508" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c508">
                           <label class="govuk-label govuk-checkboxes__label" for="c508">Vessel licensing and lists</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c509" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c509">
                           <label class="govuk-label govuk-checkboxes__label" for="c509">Vessel monitoring systems</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c510" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c510">
                           <label class="govuk-label govuk-checkboxes__label" for="c510">Vessel surveys and inspections</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c511" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c511">
                           <label class="govuk-label govuk-checkboxes__label" for="c511">Vessel licensing</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c512" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c512">
                           <label class="govuk-label govuk-checkboxes__label" for="c512">Vessel and crew safety and certification</label>
                         </div>
                       </li>
@@ -3278,37 +3278,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c513" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c513">
                       <label class="govuk-label govuk-checkboxes__label" for="c513">Fishing regulations, monitoring and enforcement</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c514" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c514">
                           <label class="govuk-label govuk-checkboxes__label" for="c514">Fishing quota and catch limits</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c515" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c515">
                           <label class="govuk-label govuk-checkboxes__label" for="c515">Sales notes and electronic recording systems</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c516" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c516">
                           <label class="govuk-label govuk-checkboxes__label" for="c516">Fisheries statistics</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c517" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c517">
                           <label class="govuk-label govuk-checkboxes__label" for="c517">First sale marine fish</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c518" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c518">
                           <label class="govuk-label govuk-checkboxes__label" for="c518">Catch Quota Trials</label>
                         </div>
                       </li>
@@ -3318,37 +3318,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c519" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c519">
                   <label class="govuk-label govuk-checkboxes__label" for="c519">Oil, gas and coal</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c520" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c520">
                       <label class="govuk-label govuk-checkboxes__label" for="c520">Coal</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c521" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c521">
                           <label class="govuk-label govuk-checkboxes__label" for="c521">Property and development</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c522" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c522">
                           <label class="govuk-label govuk-checkboxes__label" for="c522">Mining reports and data</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c523" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c523">
                           <label class="govuk-label govuk-checkboxes__label" for="c523">Mining permits and licences</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c524" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c524">
                           <label class="govuk-label govuk-checkboxes__label" for="c524">Mine water management</label>
                         </div>
                       </li>
@@ -3356,37 +3356,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c525" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c525">
                       <label class="govuk-label govuk-checkboxes__label" for="c525">Chemicals</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c526" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c526">
                           <label class="govuk-label govuk-checkboxes__label" for="c526">Mercury</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c527" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c527">
                           <label class="govuk-label govuk-checkboxes__label" for="c527">F-gases and HCFCs</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c528" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c528">
                           <label class="govuk-label govuk-checkboxes__label" for="c528">Contaminated land</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c529" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c529">
                           <label class="govuk-label govuk-checkboxes__label" for="c529">Polychlorinated biphenyl (PCBs)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c530" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c530">
                           <label class="govuk-label govuk-checkboxes__label" for="c530">REACH regulations</label>
                         </div>
                       </li>
@@ -3394,37 +3394,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c531" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c531">
                       <label class="govuk-label govuk-checkboxes__label" for="c531">Oil spills</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c532" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c532">
                       <label class="govuk-label govuk-checkboxes__label" for="c532">Onshore oil and gas</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c533" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c533">
                       <label class="govuk-label govuk-checkboxes__label" for="c533">Oil and gas licensing</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c534" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c534">
                       <label class="govuk-label govuk-checkboxes__label" for="c534">Oil and gas finance and taxation</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c535" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c535">
                           <label class="govuk-label govuk-checkboxes__label" for="c535">Tax and profits</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c536" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c536">
                           <label class="govuk-label govuk-checkboxes__label" for="c536">Market values</label>
                         </div>
                       </li>
@@ -3432,25 +3432,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c537" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c537">
                       <label class="govuk-label govuk-checkboxes__label" for="c537">Infrastructure and decommissioning</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c538" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c538">
                       <label class="govuk-label govuk-checkboxes__label" for="c538">Fields and wells</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c539" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c539">
                       <label class="govuk-label govuk-checkboxes__label" for="c539">Exploration and production</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c540" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c540">
                       <label class="govuk-label govuk-checkboxes__label" for="c540">Carbon capture and storage</label>
                     </div>
                   </li>
@@ -3458,25 +3458,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c541" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c541">
                   <label class="govuk-label govuk-checkboxes__label" for="c541">Waste and recycling</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c542" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c542">
                       <label class="govuk-label govuk-checkboxes__label" for="c542">Radioactive and nuclear substances and waste</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c543" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c543">
                       <label class="govuk-label govuk-checkboxes__label" for="c543">Waste and environmental impact</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c544" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c544">
                       <label class="govuk-label govuk-checkboxes__label" for="c544">Waste management</label>
                     </div>
                   </li>
@@ -3484,67 +3484,67 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c545" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c545">
                   <label class="govuk-label govuk-checkboxes__label" for="c545">Food and farming</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c546" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c546">
                       <label class="govuk-label govuk-checkboxes__label" for="c546">Farming and food grants and payments</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c547" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c547">
                           <label class="govuk-label govuk-checkboxes__label" for="c547">State aid</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c548" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c548">
                           <label class="govuk-label govuk-checkboxes__label" for="c548">School milk scheme</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c549" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c549">
                           <label class="govuk-label govuk-checkboxes__label" for="c549">Rural grants and payments</label>
                         </div>
                         <ul class="govuk-list">
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c550" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c550">
                               <label class="govuk-label govuk-checkboxes__label" for="c550">Countryside stewardship</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c551" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c551">
                               <label class="govuk-label govuk-checkboxes__label" for="c551">Cross-compliance</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c552" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c552">
                               <label class="govuk-label govuk-checkboxes__label" for="c552">Common Agricultural Policy (CAP) reform</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c553" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c553">
                               <label class="govuk-label govuk-checkboxes__label" for="c553">Rural development</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c554" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c554">
                               <label class="govuk-label govuk-checkboxes__label" for="c554">Online applications and payments</label>
                             </div>
                           </li>
                           <li>
                             <div class="govuk-checkboxes__item">
-                              <input class="govuk-checkboxes__input" type="checkbox" id="c555" tabindex="-1">
+                              <input class="govuk-checkboxes__input" type="checkbox" id="c555">
                               <label class="govuk-label govuk-checkboxes__label" for="c555">Basic Payment Scheme (BPS)</label>
                             </div>
                           </li>
@@ -3552,13 +3552,13 @@
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c556" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c556">
                           <label class="govuk-label govuk-checkboxes__label" for="c556">Private storage aid</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c557" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c557">
                           <label class="govuk-label govuk-checkboxes__label" for="c557">Intervention schemes</label>
                         </div>
                       </li>
@@ -3566,49 +3566,49 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c558" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c558">
                       <label class="govuk-label govuk-checkboxes__label" for="c558">Producing and distributing food</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c559" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c559">
                           <label class="govuk-label govuk-checkboxes__label" for="c559">Sugar</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c560" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c560">
                           <label class="govuk-label govuk-checkboxes__label" for="c560">Meat production</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c561" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c561">
                           <label class="govuk-label govuk-checkboxes__label" for="c561">Import, export and distribution of food</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c562" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c562">
                           <label class="govuk-label govuk-checkboxes__label" for="c562">Dairy and milk production</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c563" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c563">
                           <label class="govuk-label govuk-checkboxes__label" for="c563">Food labelling and safety</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c564" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c564">
                           <label class="govuk-label govuk-checkboxes__label" for="c564">Egg production and marketing</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c565" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c565">
                           <label class="govuk-label govuk-checkboxes__label" for="c565">Crops and horticulture</label>
                         </div>
                       </li>
@@ -3616,73 +3616,73 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c566" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c566">
                       <label class="govuk-label govuk-checkboxes__label" for="c566">Keeping farmed animals</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c567" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c567">
                           <label class="govuk-label govuk-checkboxes__label" for="c567">Bovine tuberculosis (bovine TB)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c568" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c568">
                           <label class="govuk-label govuk-checkboxes__label" for="c568">Cattle identification, registration and movements</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c569" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c569">
                           <label class="govuk-label govuk-checkboxes__label" for="c569">Reporting disease and disease outbreaks</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c570" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c570">
                           <label class="govuk-label govuk-checkboxes__label" for="c570">Veterinary medicines</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c571" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c571">
                           <label class="govuk-label govuk-checkboxes__label" for="c571">Sheep and goats identification, registration and movements</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c572" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c572">
                           <label class="govuk-label govuk-checkboxes__label" for="c572">Shows, fairs and markets</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c573" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c573">
                           <label class="govuk-label govuk-checkboxes__label" for="c573">Poultry registration</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c574" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c574">
                           <label class="govuk-label govuk-checkboxes__label" for="c574">Pig identification, registration and movements</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c575" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c575">
                           <label class="govuk-label govuk-checkboxes__label" for="c575">Import and export of farmed animals</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c576" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c576">
                           <label class="govuk-label govuk-checkboxes__label" for="c576">Deer farming</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c577" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c577">
                           <label class="govuk-label govuk-checkboxes__label" for="c577">Cattle deaths</label>
                         </div>
                       </li>
@@ -3690,13 +3690,13 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c578" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c578">
                       <label class="govuk-label govuk-checkboxes__label" for="c578">Common Agricultural Policy reform</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c579" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c579">
                       <label class="govuk-label govuk-checkboxes__label" for="c579">Food and farming industry</label>
                     </div>
                   </li>
@@ -3704,67 +3704,67 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c580" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c580">
                   <label class="govuk-label govuk-checkboxes__label" for="c580">Marine</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c581" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c581">
                       <label class="govuk-label govuk-checkboxes__label" for="c581">Hydrography</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c582" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c582">
                       <label class="govuk-label govuk-checkboxes__label" for="c582">Marine environment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c583" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c583">
                       <label class="govuk-label govuk-checkboxes__label" for="c583">Marine planning</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c584" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c584">
                       <label class="govuk-label govuk-checkboxes__label" for="c584">Marine licences</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c585" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c585">
                       <label class="govuk-label govuk-checkboxes__label" for="c585">Treasure and wrecks</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c586" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c586">
                       <label class="govuk-label govuk-checkboxes__label" for="c586">Species protection and marine conservation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c587" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c587">
                       <label class="govuk-label govuk-checkboxes__label" for="c587">Harbour orders</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c588" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c588">
                       <label class="govuk-label govuk-checkboxes__label" for="c588">Marine protection and wildlife</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c589" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c589">
                       <label class="govuk-label govuk-checkboxes__label" for="c589">Harbours</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c590" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c590">
                       <label class="govuk-label govuk-checkboxes__label" for="c590">Sea fishing</label>
                     </div>
                   </li>
@@ -3774,25 +3774,25 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c591" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c591">
               <label class="govuk-label govuk-checkboxes__label" for="c591">Welfare</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c592" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c592">
                   <label class="govuk-label govuk-checkboxes__label" for="c592">Child Benefit</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c593" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c593">
                       <label class="govuk-label govuk-checkboxes__label" for="c593">High Income Tax Charge</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c594" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c594">
                       <label class="govuk-label govuk-checkboxes__label" for="c594">Support for families</label>
                     </div>
                   </li>
@@ -3800,61 +3800,61 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c595" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c595">
                   <label class="govuk-label govuk-checkboxes__label" for="c595">Carers and disability benefits</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c596" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c596">
                   <label class="govuk-label govuk-checkboxes__label" for="c596">Child maintenance reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c597" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c597">
                   <label class="govuk-label govuk-checkboxes__label" for="c597">Death and benefits</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c598" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c598">
                   <label class="govuk-label govuk-checkboxes__label" for="c598">Benefits for families</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c599" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c599">
                   <label class="govuk-label govuk-checkboxes__label" for="c599">Heating and housing benefits</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c600" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c600">
                   <label class="govuk-label govuk-checkboxes__label" for="c600">Tax credits</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c601" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c601">
                   <label class="govuk-label govuk-checkboxes__label" for="c601">Benefits entitlement</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c602" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c602">
                   <label class="govuk-label govuk-checkboxes__label" for="c602">Jobseeker's Allowance and low income benefits</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c603" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c603">
                   <label class="govuk-label govuk-checkboxes__label" for="c603">Universal Credit</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c604" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c604">
                   <label class="govuk-label govuk-checkboxes__label" for="c604">Welfare reform</label>
                 </div>
               </li>
@@ -3862,67 +3862,67 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c605" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c605">
               <label class="govuk-label govuk-checkboxes__label" for="c605">Housing, local and community</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c606" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c606">
                   <label class="govuk-label govuk-checkboxes__label" for="c606">Land registration</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c607" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c607">
                       <label class="govuk-label govuk-checkboxes__label" for="c607">Land Registration Data</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c608" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c608">
                       <label class="govuk-label govuk-checkboxes__label" for="c608">Land registration searches, fees and forms</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c609" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c609">
                       <label class="govuk-label govuk-checkboxes__label" for="c609">Business and mortgage services</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c610" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c610">
                           <label class="govuk-label govuk-checkboxes__label" for="c610">Property portfolio management</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c611" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c611">
                           <label class="govuk-label govuk-checkboxes__label" for="c611">Risk management</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c612" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c612">
                           <label class="govuk-label govuk-checkboxes__label" for="c612">Spatial data</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c613" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c613">
                           <label class="govuk-label govuk-checkboxes__label" for="c613">Mortgage services</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c614" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c614">
                           <label class="govuk-label govuk-checkboxes__label" for="c614">Ownership verification</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c615" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c615">
                           <label class="govuk-label govuk-checkboxes__label" for="c615">Conveyancing services</label>
                         </div>
                       </li>
@@ -3932,97 +3932,97 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c616" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c616">
                   <label class="govuk-label govuk-checkboxes__label" for="c616">Housing</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c617" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c617">
                       <label class="govuk-label govuk-checkboxes__label" for="c617">Neighbours, noise and pests</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c618" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c618">
                       <label class="govuk-label govuk-checkboxes__label" for="c618">Housing funding programmes</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c619" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c619">
                       <label class="govuk-label govuk-checkboxes__label" for="c619">Housing regulation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c620" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c620">
                       <label class="govuk-label govuk-checkboxes__label" for="c620">Recycling, rubbish, streets and roads</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c621" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c621">
                       <label class="govuk-label govuk-checkboxes__label" for="c621">Tenancies and leases</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c622" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c622">
                       <label class="govuk-label govuk-checkboxes__label" for="c622">Freehold and leasehold property</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c623" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c623">
                       <label class="govuk-label govuk-checkboxes__label" for="c623">Homebuying</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c624" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c624">
                       <label class="govuk-label govuk-checkboxes__label" for="c624">Rented housing sector</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c625" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c625">
                       <label class="govuk-label govuk-checkboxes__label" for="c625">Housing for older and vulnerable people</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c626" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c626">
                       <label class="govuk-label govuk-checkboxes__label" for="c626">Repossessions, emergency housing and evictions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c627" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c627">
                       <label class="govuk-label govuk-checkboxes__label" for="c627">Planning permission and building regulations</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c628" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c628">
                       <label class="govuk-label govuk-checkboxes__label" for="c628">Owning and renting a property</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c629" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c629">
                       <label class="govuk-label govuk-checkboxes__label" for="c629">Being a landlord and renting out a room</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c630" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c630">
                       <label class="govuk-label govuk-checkboxes__label" for="c630">Council housing and housing association</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c631" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c631">
                       <label class="govuk-label govuk-checkboxes__label" for="c631">Safety and the environment in your community</label>
                     </div>
                   </li>
@@ -4030,73 +4030,73 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c632" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c632">
                   <label class="govuk-label govuk-checkboxes__label" for="c632">Planning and building</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c633" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c633">
                       <label class="govuk-label govuk-checkboxes__label" for="c633">Party walls</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c634" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c634">
                       <label class="govuk-label govuk-checkboxes__label" for="c634">Energy efficiency in buildings</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c635" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c635">
                       <label class="govuk-label govuk-checkboxes__label" for="c635">Landscape</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c636" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c636">
                       <label class="govuk-label govuk-checkboxes__label" for="c636">Environmental planning</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c637" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c637">
                       <label class="govuk-label govuk-checkboxes__label" for="c637">Housing design and sustainability</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c638" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c638">
                       <label class="govuk-label govuk-checkboxes__label" for="c638">Land and development opportunities</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c639" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c639">
                       <label class="govuk-label govuk-checkboxes__label" for="c639">Local Plans</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c640" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c640">
                       <label class="govuk-label govuk-checkboxes__label" for="c640">Building regulations</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c641" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c641">
                           <label class="govuk-label govuk-checkboxes__label" for="c641">European legislation</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c642" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c642">
                           <label class="govuk-label govuk-checkboxes__label" for="c642">Compliance</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c643" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c643">
                           <label class="govuk-label govuk-checkboxes__label" for="c643">Doing building work</label>
                         </div>
                       </li>
@@ -4104,13 +4104,13 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c644" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c644">
                       <label class="govuk-label govuk-checkboxes__label" for="c644">Planning permission and appeals</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c645" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c645">
                           <label class="govuk-label govuk-checkboxes__label" for="c645">Make an appeal</label>
                         </div>
                       </li>
@@ -4118,31 +4118,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c646" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c646">
                       <label class="govuk-label govuk-checkboxes__label" for="c646">High streets and town centres</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c647" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c647">
                       <label class="govuk-label govuk-checkboxes__label" for="c647">Planning reform</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c648" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c648">
                       <label class="govuk-label govuk-checkboxes__label" for="c648">Building regulation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c649" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c649">
                       <label class="govuk-label govuk-checkboxes__label" for="c649">House building</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c650" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c650">
                       <label class="govuk-label govuk-checkboxes__label" for="c650">Planning system</label>
                     </div>
                   </li>
@@ -4150,7 +4150,7 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c651" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c651">
                   <label class="govuk-label govuk-checkboxes__label" for="c651">Household energy</label>
                 </div>
               </li>
@@ -4158,55 +4158,55 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c652" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c652">
               <label class="govuk-label govuk-checkboxes__label" for="c652">Life circumstances</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c653" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c653">
                   <label class="govuk-label govuk-checkboxes__label" for="c653">Having a child, parenting and adoption</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c654" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c654">
                   <label class="govuk-label govuk-checkboxes__label" for="c654">Certificates, register offices, changes of name or gender</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c655" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c655">
                   <label class="govuk-label govuk-checkboxes__label" for="c655">Lasting power of attorney, being in care and your financial affairs</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c656" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c656">
                   <label class="govuk-label govuk-checkboxes__label" for="c656">Marriage, civil partnership and divorce</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c657" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c657">
                       <label class="govuk-label govuk-checkboxes__label" for="c657">Child maintenance</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c658" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c658">
                       <label class="govuk-label govuk-checkboxes__label" for="c658">Help and support if you have children</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c659" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c659">
                       <label class="govuk-label govuk-checkboxes__label" for="c659">Getting separated or divorced</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c660" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c660">
                       <label class="govuk-label govuk-checkboxes__label" for="c660">Getting married</label>
                     </div>
                   </li>
@@ -4214,13 +4214,13 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c661" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c661">
                   <label class="govuk-label govuk-checkboxes__label" for="c661">Death and bereavement</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c662" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c662">
                       <label class="govuk-label govuk-checkboxes__label" for="c662">Death registration disclosure</label>
                     </div>
                   </li>
@@ -4230,55 +4230,55 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c663" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c663">
               <label class="govuk-label govuk-checkboxes__label" for="c663">International</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c664" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c664">
                   <label class="govuk-label govuk-checkboxes__label" for="c664">Foreign affairs</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c665" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c665">
                       <label class="govuk-label govuk-checkboxes__label" for="c665">Afghanistan</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c666" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c666">
                       <label class="govuk-label govuk-checkboxes__label" for="c666">Conflict in fragile states</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c667" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c667">
                       <label class="govuk-label govuk-checkboxes__label" for="c667">UK Overseas Territories</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c668" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c668">
                       <label class="govuk-label govuk-checkboxes__label" for="c668">Iran's nuclear programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c669" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c669">
                       <label class="govuk-label govuk-checkboxes__label" for="c669">Piracy off the coast of Somalia</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c670" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c670">
                       <label class="govuk-label govuk-checkboxes__label" for="c670">Falkland Islanders' right to self-determination</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c671" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c671">
                       <label class="govuk-label govuk-checkboxes__label" for="c671">Peace and stability in the Middle East and North Africa</label>
                     </div>
                   </li>
@@ -4286,73 +4286,73 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c672" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c672">
                   <label class="govuk-label govuk-checkboxes__label" for="c672">International aid and development</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c673" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c673">
                       <label class="govuk-label govuk-checkboxes__label" for="c673">Women and girls in developing countries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c674" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c674">
                       <label class="govuk-label govuk-checkboxes__label" for="c674">Health in developing countries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c675" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c675">
                       <label class="govuk-label govuk-checkboxes__label" for="c675">Governance in developing countries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c676" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c676">
                       <label class="govuk-label govuk-checkboxes__label" for="c676">Overseas aid transparency</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c677" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c677">
                       <label class="govuk-label govuk-checkboxes__label" for="c677">Overseas aid effectiveness</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c678" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c678">
                       <label class="govuk-label govuk-checkboxes__label" for="c678">Climate change impact in developing countries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c679" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c679">
                       <label class="govuk-label govuk-checkboxes__label" for="c679">Economic growth in developing countries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c680" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c680">
                       <label class="govuk-label govuk-checkboxes__label" for="c680">Hunger and malnutrition in developing countries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c681" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c681">
                       <label class="govuk-label govuk-checkboxes__label" for="c681">Education in developing countries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c682" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c682">
                       <label class="govuk-label govuk-checkboxes__label" for="c682">Humanitarian emergencies</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c683" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c683">
                       <label class="govuk-label govuk-checkboxes__label" for="c683">Water and sanitation in developing countries</label>
                     </div>
                   </li>
@@ -4360,31 +4360,31 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c684" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c684">
                   <label class="govuk-label govuk-checkboxes__label" for="c684">Human rights internationally</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c685" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c685">
                   <label class="govuk-label govuk-checkboxes__label" for="c685">UK prosperity and security: Asia, Latin America and Africa</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c686" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c686">
                   <label class="govuk-label govuk-checkboxes__label" for="c686">Anti-corruption</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c687" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c687">
                   <label class="govuk-label govuk-checkboxes__label" for="c687">The Commonwealth</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c688" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c688">
                   <label class="govuk-label govuk-checkboxes__label" for="c688">Sexual violence in conflict</label>
                 </div>
               </li>
@@ -4392,25 +4392,25 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c689" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c689">
               <label class="govuk-label govuk-checkboxes__label" for="c689">Health and social care</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c690" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c690">
                   <label class="govuk-label govuk-checkboxes__label" for="c690">Social care</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c691" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c691">
                       <label class="govuk-label govuk-checkboxes__label" for="c691">Health and social care integration</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c692" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c692">
                       <label class="govuk-label govuk-checkboxes__label" for="c692">Research and innovation in health and social care</label>
                     </div>
                   </li>
@@ -4418,43 +4418,43 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c693" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c693">
                   <label class="govuk-label govuk-checkboxes__label" for="c693">End of life care</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c694" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c694">
                   <label class="govuk-label govuk-checkboxes__label" for="c694">Carers' health</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c695" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c695">
                   <label class="govuk-label govuk-checkboxes__label" for="c695">Disabled people</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c696" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c696">
                       <label class="govuk-label govuk-checkboxes__label" for="c696">Disability equipment and transport</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c697" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c697">
                       <label class="govuk-label govuk-checkboxes__label" for="c697">Disability rights</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c698" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c698">
                       <label class="govuk-label govuk-checkboxes__label" for="c698">Benefits and financial help</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c699" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c699">
                       <label class="govuk-label govuk-checkboxes__label" for="c699">Carers</label>
                     </div>
                   </li>
@@ -4462,61 +4462,61 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c700" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c700">
                   <label class="govuk-label govuk-checkboxes__label" for="c700">Health protection</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c701" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c701">
                       <label class="govuk-label govuk-checkboxes__label" for="c701">Radiation protection</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c702" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c702">
                       <label class="govuk-label govuk-checkboxes__label" for="c702">Health emergency planning</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c703" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c703">
                       <label class="govuk-label govuk-checkboxes__label" for="c703">Chemical and environmental hazards</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c704" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c704">
                       <label class="govuk-label govuk-checkboxes__label" for="c704">Research, testing and standards</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c705" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c705">
                       <label class="govuk-label govuk-checkboxes__label" for="c705">Health surveillance and reporting programmes</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c706" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c706">
                       <label class="govuk-label govuk-checkboxes__label" for="c706">Laboratories and reference facilities</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c707" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c707">
                       <label class="govuk-label govuk-checkboxes__label" for="c707">Migrant health guide</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c708" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c708">
                           <label class="govuk-label govuk-checkboxes__label" for="c708">Assessing patients</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c709" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c709">
                           <label class="govuk-label govuk-checkboxes__label" for="c709">Migrants and the NHS</label>
                         </div>
                       </li>
@@ -4524,19 +4524,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c710" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c710">
                       <label class="govuk-label govuk-checkboxes__label" for="c710">Infectious diseases</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c711" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c711">
                       <label class="govuk-label govuk-checkboxes__label" for="c711">Immunisation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c712" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c712">
                       <label class="govuk-label govuk-checkboxes__label" for="c712">Emergency response</label>
                     </div>
                   </li>
@@ -4544,79 +4544,79 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c713" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c713">
                   <label class="govuk-label govuk-checkboxes__label" for="c713">Population screening programmes</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c714" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c714">
                       <label class="govuk-label govuk-checkboxes__label" for="c714">Quality assurance in population screening</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c715" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c715">
                       <label class="govuk-label govuk-checkboxes__label" for="c715">NHS newborn hearing screening programme (NHSP)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c716" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c716">
                       <label class="govuk-label govuk-checkboxes__label" for="c716">NHS sickle cell and thalassaemia (SCT) screening programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c717" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c717">
                       <label class="govuk-label govuk-checkboxes__label" for="c717">NHS newborn blood spot (NBS) screening programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c718" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c718">
                       <label class="govuk-label govuk-checkboxes__label" for="c718">NHS newborn and infant physical examination (NIPE) screening programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c719" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c719">
                       <label class="govuk-label govuk-checkboxes__label" for="c719">NHS infectious diseases in pregnancy screening (IDPS) programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c720" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c720">
                       <label class="govuk-label govuk-checkboxes__label" for="c720">NHS diabetic eye screening (DES) programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c721" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c721">
                       <label class="govuk-label govuk-checkboxes__label" for="c721">NHS cervical screening (CSP) programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c722" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c722">
                       <label class="govuk-label govuk-checkboxes__label" for="c722">NHS fetal anomaly screening programme (FASP)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c723" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c723">
                       <label class="govuk-label govuk-checkboxes__label" for="c723">NHS breast screening (BSP) programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c724" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c724">
                       <label class="govuk-label govuk-checkboxes__label" for="c724">NHS bowel cancer screening (BCSP) programme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c725" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c725">
                       <label class="govuk-label govuk-checkboxes__label" for="c725">NHS abdominal aortic aneurysm (AAA) programme</label>
                     </div>
                   </li>
@@ -4624,37 +4624,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c726" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c726">
                   <label class="govuk-label govuk-checkboxes__label" for="c726">Medicines, medical devices and blood regulation and safety</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c727" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c727">
                       <label class="govuk-label govuk-checkboxes__label" for="c727">Clinical trials and investigations</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c728" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c728">
                       <label class="govuk-label govuk-checkboxes__label" for="c728">Medical devices regulation and safety</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c729" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c729">
                       <label class="govuk-label govuk-checkboxes__label" for="c729">Conferences and events</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c730" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c730">
                       <label class="govuk-label govuk-checkboxes__label" for="c730">Vigilance, safety alerts and guidance</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c731" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c731">
                           <label class="govuk-label govuk-checkboxes__label" for="c731">Alerts and recalls</label>
                         </div>
                       </li>
@@ -4662,31 +4662,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c732" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c732">
                       <label class="govuk-label govuk-checkboxes__label" for="c732">Herbal and homeopathic medicines</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c733" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c733">
                       <label class="govuk-label govuk-checkboxes__label" for="c733">Manufacturing, wholesaling, importing and exporting medicines</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c734" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c734">
                       <label class="govuk-label govuk-checkboxes__label" for="c734">Blood regulation and safety</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c735" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c735">
                       <label class="govuk-label govuk-checkboxes__label" for="c735">Marketing authorisations, variations and licensing guidance</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c736" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c736">
                       <label class="govuk-label govuk-checkboxes__label" for="c736">Good practice, inspections and enforcement</label>
                     </div>
                   </li>
@@ -4694,31 +4694,31 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c737" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c737">
                   <label class="govuk-label govuk-checkboxes__label" for="c737">National Health Service</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c738" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c738">
                       <label class="govuk-label govuk-checkboxes__label" for="c738">Children's health</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c739" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c739">
                       <label class="govuk-label govuk-checkboxes__label" for="c739">Compassionate care in the NHS</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c740" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c740">
                       <label class="govuk-label govuk-checkboxes__label" for="c740">NHS efficiency</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c741" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c741">
                       <label class="govuk-label govuk-checkboxes__label" for="c741">Patient safety</label>
                     </div>
                   </li>
@@ -4726,25 +4726,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c742" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c742">
                   <label class="govuk-label govuk-checkboxes__label" for="c742">Public health</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c743" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c743">
                       <label class="govuk-label govuk-checkboxes__label" for="c743">Abortion</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c744" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c744">
                       <label class="govuk-label govuk-checkboxes__label" for="c744">Mental health</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c745" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c745">
                           <label class="govuk-label govuk-checkboxes__label" for="c745">Mental health service reform</label>
                         </div>
                       </li>
@@ -4752,25 +4752,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c746" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c746">
                       <label class="govuk-label govuk-checkboxes__label" for="c746">Health conditions</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c747" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c747">
                           <label class="govuk-label govuk-checkboxes__label" for="c747">Long term health conditions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c748" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c748">
                           <label class="govuk-label govuk-checkboxes__label" for="c748">Dementia</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c749" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c749">
                           <label class="govuk-label govuk-checkboxes__label" for="c749">Autism</label>
                         </div>
                       </li>
@@ -4778,61 +4778,61 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c750" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c750">
                       <label class="govuk-label govuk-checkboxes__label" for="c750">Dentistry</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c751" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c751">
                       <label class="govuk-label govuk-checkboxes__label" for="c751">Ophthalmology</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c752" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c752">
                       <label class="govuk-label govuk-checkboxes__label" for="c752">Technology in health and social care</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c753" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c753">
                       <label class="govuk-label govuk-checkboxes__label" for="c753">Health improvement</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c754" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c754">
                           <label class="govuk-label govuk-checkboxes__label" for="c754">Obesity</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c755" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c755">
                           <label class="govuk-label govuk-checkboxes__label" for="c755">Healthy eating</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c756" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c756">
                           <label class="govuk-label govuk-checkboxes__label" for="c756">Cancer research and treatment</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c757" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c757">
                           <label class="govuk-label govuk-checkboxes__label" for="c757">Drug misuse and dependency</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c758" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c758">
                           <label class="govuk-label govuk-checkboxes__label" for="c758">Harmful drinking</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c759" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c759">
                           <label class="govuk-label govuk-checkboxes__label" for="c759">Smoking</label>
                         </div>
                       </li>
@@ -4844,61 +4844,61 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c760" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c760">
               <label class="govuk-label govuk-checkboxes__label" for="c760">Defence and armed forces</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c761" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c761">
                   <label class="govuk-label govuk-checkboxes__label" for="c761">UK nuclear deterrent</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c762" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c762">
                   <label class="govuk-label govuk-checkboxes__label" for="c762">Weapons proliferation</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c763" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c763">
                   <label class="govuk-label govuk-checkboxes__label" for="c763">Armed forces support for activities in the UK</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c764" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c764">
                   <label class="govuk-label govuk-checkboxes__label" for="c764">Armed forces</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c765" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c765">
                   <label class="govuk-label govuk-checkboxes__label" for="c765">Support services for veterans and their families</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c766" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c766">
                   <label class="govuk-label govuk-checkboxes__label" for="c766">Support services for military and defence personnel and their families</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c767" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c767">
                       <label class="govuk-label govuk-checkboxes__label" for="c767">Pensions and compensation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c768" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c768">
                       <label class="govuk-label govuk-checkboxes__label" for="c768">Housing and accommodation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c769" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c769">
                       <label class="govuk-label govuk-checkboxes__label" for="c769">British Forces Post Office</label>
                     </div>
                   </li>
@@ -4906,25 +4906,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c770" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c770">
                   <label class="govuk-label govuk-checkboxes__label" for="c770">Military awards and commemorations</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c771" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c771">
                       <label class="govuk-label govuk-checkboxes__label" for="c771">Veterans</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c772" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c772">
                       <label class="govuk-label govuk-checkboxes__label" for="c772">Medals</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c773" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c773">
                       <label class="govuk-label govuk-checkboxes__label" for="c773">Honours and awards</label>
                     </div>
                   </li>
@@ -4932,37 +4932,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c774" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c774">
                   <label class="govuk-label govuk-checkboxes__label" for="c774">Ministry of Defence estate</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c775" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c775">
                       <label class="govuk-label govuk-checkboxes__label" for="c775">Sale of land</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c776" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c776">
                       <label class="govuk-label govuk-checkboxes__label" for="c776">Public access</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c777" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c777">
                       <label class="govuk-label govuk-checkboxes__label" for="c777">Military crash sites</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c778" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c778">
                       <label class="govuk-label govuk-checkboxes__label" for="c778">Film locations</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c779" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c779">
                       <label class="govuk-label govuk-checkboxes__label" for="c779">Art collection</label>
                     </div>
                   </li>
@@ -4970,43 +4970,43 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c780" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c780">
                   <label class="govuk-label govuk-checkboxes__label" for="c780">Military recruitment, training and operations</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c781" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c781">
                   <label class="govuk-label govuk-checkboxes__label" for="c781">Military equipment, logistics and technology</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c782" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c782">
                   <label class="govuk-label govuk-checkboxes__label" for="c782">International defence commitments</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c783" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c783">
                   <label class="govuk-label govuk-checkboxes__label" for="c783">Stability in the Western Balkans</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c784" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c784">
                   <label class="govuk-label govuk-checkboxes__label" for="c784">Armed forces and Ministry of Defence reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c785" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c785">
                   <label class="govuk-label govuk-checkboxes__label" for="c785">Armed Forces Covenant</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c786" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c786">
                   <label class="govuk-label govuk-checkboxes__label" for="c786">Nuclear disarmament</label>
                 </div>
               </li>
@@ -5014,49 +5014,49 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c787" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c787">
               <label class="govuk-label govuk-checkboxes__label" for="c787">Crime, justice and law</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c788" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c788">
                   <label class="govuk-label govuk-checkboxes__label" for="c788">Young people and the law</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c789" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c789">
                   <label class="govuk-label govuk-checkboxes__label" for="c789">Statutory rights</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c790" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c790">
                   <label class="govuk-label govuk-checkboxes__label" for="c790">Your rights and the law</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c791" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c791">
                   <label class="govuk-label govuk-checkboxes__label" for="c791">Crime prevention</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c792" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c792">
                   <label class="govuk-label govuk-checkboxes__label" for="c792">Prisons and probation</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c793" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c793">
                       <label class="govuk-label govuk-checkboxes__label" for="c793">Prisons healthcare</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c794" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c794">
                       <label class="govuk-label govuk-checkboxes__label" for="c794">MAPPA</label>
                     </div>
                   </li>
@@ -5064,43 +5064,43 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c795" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c795">
                   <label class="govuk-label govuk-checkboxes__label" for="c795">Legal aid</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c796" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c796">
                       <label class="govuk-label govuk-checkboxes__label" for="c796">Civil and crime contracts</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c797" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c797">
                       <label class="govuk-label govuk-checkboxes__label" for="c797">Tenders</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c798" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c798">
                       <label class="govuk-label govuk-checkboxes__label" for="c798">Payments and processing</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c799" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c799">
                       <label class="govuk-label govuk-checkboxes__label" for="c799">Electronic working</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c800" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c800">
                       <label class="govuk-label govuk-checkboxes__label" for="c800">High cost and complex cases</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c801" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c801">
                       <label class="govuk-label govuk-checkboxes__label" for="c801">Crime</label>
                     </div>
                   </li>
@@ -5108,91 +5108,91 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c802" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c802">
                   <label class="govuk-label govuk-checkboxes__label" for="c802">Reporting crimes and getting compensation</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c803" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c803">
                   <label class="govuk-label govuk-checkboxes__label" for="c803">Courts, sentencing and tribunals</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c804" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c804">
                   <label class="govuk-label govuk-checkboxes__label" for="c804">Counter-terrorism</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c805" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c805">
                   <label class="govuk-label govuk-checkboxes__label" for="c805">Policing</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c806" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c806">
                   <label class="govuk-label govuk-checkboxes__label" for="c806">Knife, gun and gang crime</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c807" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c807">
                   <label class="govuk-label govuk-checkboxes__label" for="c807">Reoffending and rehabilitation</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c808" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c808">
                   <label class="govuk-label govuk-checkboxes__label" for="c808">Legal aid reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c809" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c809">
                   <label class="govuk-label govuk-checkboxes__label" for="c809">Attorney General guidance to the legal profession</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c810" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c810">
                   <label class="govuk-label govuk-checkboxes__label" for="c810">Forced marriage</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c811" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c811">
                   <label class="govuk-label govuk-checkboxes__label" for="c811">Domestic violence</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c812" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c812">
                   <label class="govuk-label govuk-checkboxes__label" for="c812">Law and practice</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c813" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c813">
                       <label class="govuk-label govuk-checkboxes__label" for="c813">Copyright</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c814" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c814">
                       <label class="govuk-label govuk-checkboxes__label" for="c814">Designs</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c815" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c815">
                       <label class="govuk-label govuk-checkboxes__label" for="c815">Patents</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c816" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c816">
                       <label class="govuk-label govuk-checkboxes__label" for="c816">Trade marks</label>
                     </div>
                   </li>
@@ -5200,67 +5200,67 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c817" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c817">
                   <label class="govuk-label govuk-checkboxes__label" for="c817">Family justice system</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c818" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c818">
                   <label class="govuk-label govuk-checkboxes__label" for="c818">Justice system transparency</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c819" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c819">
                   <label class="govuk-label govuk-checkboxes__label" for="c819">Violence against women and girls</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c820" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c820">
                   <label class="govuk-label govuk-checkboxes__label" for="c820">Criminal justice reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c821" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c821">
                   <label class="govuk-label govuk-checkboxes__label" for="c821">Civil justice reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c822" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c822">
                   <label class="govuk-label govuk-checkboxes__label" for="c822">Criminal record disclosure</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c823" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c823">
                   <label class="govuk-label govuk-checkboxes__label" for="c823">Victims of crime</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c824" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c824">
                   <label class="govuk-label govuk-checkboxes__label" for="c824">Sentencing reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c825" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c825">
                   <label class="govuk-label govuk-checkboxes__label" for="c825">Administrative justice reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c826" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c826">
                   <label class="govuk-label govuk-checkboxes__label" for="c826">Byelaws</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c827" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c827">
                   <label class="govuk-label govuk-checkboxes__label" for="c827">Data protection</label>
                 </div>
               </li>
@@ -5268,73 +5268,73 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c828" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c828">
               <label class="govuk-label govuk-checkboxes__label" for="c828">Regional and local government</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c829" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c829">
                   <label class="govuk-label govuk-checkboxes__label" for="c829">Devolution</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c830" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c830">
                   <label class="govuk-label govuk-checkboxes__label" for="c830">Local government</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c831" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c831">
                       <label class="govuk-label govuk-checkboxes__label" for="c831">Local government pensions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c832" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c832">
                       <label class="govuk-label govuk-checkboxes__label" for="c832">Local government finance and capital assets</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c833" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c833">
                       <label class="govuk-label govuk-checkboxes__label" for="c833">Local Housing Allowance</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c834" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c834">
                       <label class="govuk-label govuk-checkboxes__label" for="c834">Data collection and reporting</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c835" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c835">
                       <label class="govuk-label govuk-checkboxes__label" for="c835">Council Tax</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c836" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c836">
                           <label class="govuk-label govuk-checkboxes__label" for="c836">Council Tax reform</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c837" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c837">
                           <label class="govuk-label govuk-checkboxes__label" for="c837">Appeals and reductions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c838" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c838">
                           <label class="govuk-label govuk-checkboxes__label" for="c838">Renting</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c839" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c839">
                           <label class="govuk-label govuk-checkboxes__label" for="c839">Council Tax bands</label>
                         </div>
                       </li>
@@ -5342,31 +5342,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c840" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c840">
                       <label class="govuk-label govuk-checkboxes__label" for="c840">Councils and elections</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c841" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c841">
                       <label class="govuk-label govuk-checkboxes__label" for="c841">Business rates</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c842" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c842">
                           <label class="govuk-label govuk-checkboxes__label" for="c842">Relief, refunds and rebates</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c843" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c843">
                           <label class="govuk-label govuk-checkboxes__label" for="c843">Your rateable value</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c844" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c844">
                           <label class="govuk-label govuk-checkboxes__label" for="c844">Submit your rent or lease details</label>
                         </div>
                       </li>
@@ -5376,19 +5376,19 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c845" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c845">
                   <label class="govuk-label govuk-checkboxes__label" for="c845">Wales</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c846" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c846">
                       <label class="govuk-label govuk-checkboxes__label" for="c846">Economic growth in Wales</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c847" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c847">
                       <label class="govuk-label govuk-checkboxes__label" for="c847">Welsh devolution</label>
                     </div>
                   </li>
@@ -5396,37 +5396,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c848" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c848">
                   <label class="govuk-label govuk-checkboxes__label" for="c848">Local government spending</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c849" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c849">
                   <label class="govuk-label govuk-checkboxes__label" for="c849">Northern Ireland</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c850" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c850">
                       <label class="govuk-label govuk-checkboxes__label" for="c850">Northern Ireland security</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c851" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c851">
                       <label class="govuk-label govuk-checkboxes__label" for="c851">Northern Ireland economy</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c852" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c852">
                       <label class="govuk-label govuk-checkboxes__label" for="c852">Northern Ireland political stability</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c853" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c853">
                       <label class="govuk-label govuk-checkboxes__label" for="c853">Northern Ireland community relations</label>
                     </div>
                   </li>
@@ -5434,25 +5434,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c854" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c854">
                   <label class="govuk-label govuk-checkboxes__label" for="c854">Localism</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c855" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c855">
                   <label class="govuk-label govuk-checkboxes__label" for="c855">Scotland</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c856" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c856">
                       <label class="govuk-label govuk-checkboxes__label" for="c856">Scottish constitution</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c857" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c857">
                       <label class="govuk-label govuk-checkboxes__label" for="c857">Scottish devolution</label>
                     </div>
                   </li>
@@ -5460,7 +5460,7 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c858" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c858">
                   <label class="govuk-label govuk-checkboxes__label" for="c858">Local councils and services</label>
                 </div>
               </li>
@@ -5468,49 +5468,49 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c859" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c859">
               <label class="govuk-label govuk-checkboxes__label" for="c859">Society and culture</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c860" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c860">
                   <label class="govuk-label govuk-checkboxes__label" for="c860">Charities, volunteering and honours</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c861" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c861">
                   <label class="govuk-label govuk-checkboxes__label" for="c861">British citizenship</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c862" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c862">
                   <label class="govuk-label govuk-checkboxes__label" for="c862">Community and society</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c863" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c863">
                       <label class="govuk-label govuk-checkboxes__label" for="c863">Community integration</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c864" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c864">
                       <label class="govuk-label govuk-checkboxes__label" for="c864">National Lottery funding</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c865" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c865">
                       <label class="govuk-label govuk-checkboxes__label" for="c865">Social investment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c866" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c866">
                       <label class="govuk-label govuk-checkboxes__label" for="c866">Social action</label>
                     </div>
                   </li>
@@ -5518,25 +5518,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c867" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c867">
                   <label class="govuk-label govuk-checkboxes__label" for="c867">Arts and culture</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c868" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c868">
                       <label class="govuk-label govuk-checkboxes__label" for="c868">Museums and galleries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c869" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c869">
                       <label class="govuk-label govuk-checkboxes__label" for="c869">Library services</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c870" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c870">
                       <label class="govuk-label govuk-checkboxes__label" for="c870">Conservation of historic buildings and monuments</label>
                     </div>
                   </li>
@@ -5544,37 +5544,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c871" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c871">
                   <label class="govuk-label govuk-checkboxes__label" for="c871">Sports and leisure</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c872" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c872">
                       <label class="govuk-label govuk-checkboxes__label" for="c872">2012 Olympic and Paralympic legacy</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c873" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c873">
                       <label class="govuk-label govuk-checkboxes__label" for="c873">Recreation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c874" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c874">
                       <label class="govuk-label govuk-checkboxes__label" for="c874">Community amateur sports clubs (CASCs)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c875" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c875">
                       <label class="govuk-label govuk-checkboxes__label" for="c875">Elite sports performance</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c876" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c876">
                       <label class="govuk-label govuk-checkboxes__label" for="c876">Sports participation</label>
                     </div>
                   </li>
@@ -5582,31 +5582,31 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c877" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c877">
                   <label class="govuk-label govuk-checkboxes__label" for="c877">National events and ceremonies</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c878" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c878">
                   <label class="govuk-label govuk-checkboxes__label" for="c878">Equality, rights and citizenship</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c879" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c879">
                       <label class="govuk-label govuk-checkboxes__label" for="c879">Equality</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c880" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c880">
                       <label class="govuk-label govuk-checkboxes__label" for="c880">Poverty and social justice</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c881" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c881">
                       <label class="govuk-label govuk-checkboxes__label" for="c881">Social mobility</label>
                     </div>
                   </li>
@@ -5614,25 +5614,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c882" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c882">
                   <label class="govuk-label govuk-checkboxes__label" for="c882">Loneliness</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c883" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c883">
                   <label class="govuk-label govuk-checkboxes__label" for="c883">Tourism</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c884" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c884">
                   <label class="govuk-label govuk-checkboxes__label" for="c884">Digital inclusion and accessibility</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c885" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c885">
                   <label class="govuk-label govuk-checkboxes__label" for="c885">Young people</label>
                 </div>
               </li>
@@ -5640,43 +5640,43 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c886" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c886">
               <label class="govuk-label govuk-checkboxes__label" for="c886">Government</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c887" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c887">
                   <label class="govuk-label govuk-checkboxes__label" for="c887">Public sector land use</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c888" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c888">
                   <label class="govuk-label govuk-checkboxes__label" for="c888">Brexit</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c889" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c889">
                   <label class="govuk-label govuk-checkboxes__label" for="c889">National security</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c890" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c890">
                   <label class="govuk-label govuk-checkboxes__label" for="c890">Government efficiency, transparency and accountability</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c891" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c891">
                       <label class="govuk-label govuk-checkboxes__label" for="c891">Government spending</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c892" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c892">
                           <label class="govuk-label govuk-checkboxes__label" for="c892">Government funding programmes</label>
                         </div>
                       </li>
@@ -5684,13 +5684,13 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c893" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c893">
                       <label class="govuk-label govuk-checkboxes__label" for="c893">Major project management</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c894" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c894">
                       <label class="govuk-label govuk-checkboxes__label" for="c894">Deficit reduction</label>
                     </div>
                   </li>
@@ -5698,13 +5698,13 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c895" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c895">
                   <label class="govuk-label govuk-checkboxes__label" for="c895">Emergency preparation, response and recovery</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c896" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c896">
                       <label class="govuk-label govuk-checkboxes__label" for="c896">Fire prevention and rescue</label>
                     </div>
                   </li>
@@ -5712,67 +5712,67 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c897" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c897">
                   <label class="govuk-label govuk-checkboxes__label" for="c897">Public services</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c898" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c898">
                   <label class="govuk-label govuk-checkboxes__label" for="c898">Government technology and digital services</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c899" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c899">
                       <label class="govuk-label govuk-checkboxes__label" for="c899">GOV.UK services</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c900" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c900">
                           <label class="govuk-label govuk-checkboxes__label" for="c900">GOV.UK Pay</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c901" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c901">
                           <label class="govuk-label govuk-checkboxes__label" for="c901">GOV.UK Verify</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c902" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c902">
                           <label class="govuk-label govuk-checkboxes__label" for="c902">GOV.UK Platform as a Service (PaaS)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c903" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c903">
                           <label class="govuk-label govuk-checkboxes__label" for="c903">GOV.UK Proposition</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c904" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c904">
                           <label class="govuk-label govuk-checkboxes__label" for="c904">GOV.UK Notify</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c905" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c905">
                           <label class="govuk-label govuk-checkboxes__label" for="c905">GovWifi</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c906" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c906">
                           <label class="govuk-label govuk-checkboxes__label" for="c906">Performance platform</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c907" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c907">
                           <label class="govuk-label govuk-checkboxes__label" for="c907">GOV.UK Registers</label>
                         </div>
                       </li>
@@ -5780,19 +5780,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c908" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c908">
                       <label class="govuk-label govuk-checkboxes__label" for="c908">Networks and telecommunications</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c909" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c909">
                           <label class="govuk-label govuk-checkboxes__label" for="c909">Telecommunications</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c910" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c910">
                           <label class="govuk-label govuk-checkboxes__label" for="c910">Networking</label>
                         </div>
                       </li>
@@ -5800,19 +5800,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c911" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c911">
                       <label class="govuk-label govuk-checkboxes__label" for="c911">Open source and open standards</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c912" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c912">
                           <label class="govuk-label govuk-checkboxes__label" for="c912">Open standards</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c913" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c913">
                           <label class="govuk-label govuk-checkboxes__label" for="c913">Open source</label>
                         </div>
                       </li>
@@ -5820,55 +5820,55 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c914" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c914">
                       <label class="govuk-label govuk-checkboxes__label" for="c914">Digital security</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c915" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c915">
                           <label class="govuk-label govuk-checkboxes__label" for="c915">Cloud security</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c916" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c916">
                           <label class="govuk-label govuk-checkboxes__label" for="c916">Digital service security</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c917" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c917">
                           <label class="govuk-label govuk-checkboxes__label" for="c917">End user devices</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c918" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c918">
                           <label class="govuk-label govuk-checkboxes__label" for="c918">Identity assurance</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c919" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c919">
                           <label class="govuk-label govuk-checkboxes__label" for="c919">Passwords</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c920" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c920">
                           <label class="govuk-label govuk-checkboxes__label" for="c920">Phishing</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c921" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c921">
                           <label class="govuk-label govuk-checkboxes__label" for="c921">Email</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c922" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c922">
                           <label class="govuk-label govuk-checkboxes__label" for="c922">Risk management</label>
                         </div>
                       </li>
@@ -5876,19 +5876,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c923" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c923">
                       <label class="govuk-label govuk-checkboxes__label" for="c923">APIs and app development</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c924" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c924">
                           <label class="govuk-label govuk-checkboxes__label" for="c924">Application development</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c925" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c925">
                           <label class="govuk-label govuk-checkboxes__label" for="c925">APIs</label>
                         </div>
                       </li>
@@ -5896,25 +5896,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c926" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c926">
                       <label class="govuk-label govuk-checkboxes__label" for="c926">Design and build of government services</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c927" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c927">
                           <label class="govuk-label govuk-checkboxes__label" for="c927">Government content and publishing</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c928" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c928">
                           <label class="govuk-label govuk-checkboxes__label" for="c928">Design principles</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c929" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c929">
                           <label class="govuk-label govuk-checkboxes__label" for="c929">Digital Service Standard</label>
                         </div>
                       </li>
@@ -5922,19 +5922,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c930" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c930">
                       <label class="govuk-label govuk-checkboxes__label" for="c930">Data</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c931" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c931">
                           <label class="govuk-label govuk-checkboxes__label" for="c931">Data usage</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c932" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c932">
                           <label class="govuk-label govuk-checkboxes__label" for="c932">Data provisioning</label>
                         </div>
                       </li>
@@ -5942,25 +5942,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c933" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c933">
                       <label class="govuk-label govuk-checkboxes__label" for="c933">User research</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c934" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c934">
                       <label class="govuk-label govuk-checkboxes__label" for="c934">Public Service Network (PSN)</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c935" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c935">
                       <label class="govuk-label govuk-checkboxes__label" for="c935">Managing government websites</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c936" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c936">
                           <label class="govuk-label govuk-checkboxes__label" for="c936">Hosting your service</label>
                         </div>
                       </li>
@@ -5968,37 +5968,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c937" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c937">
                       <label class="govuk-label govuk-checkboxes__label" for="c937">Digital transformation</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c938" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c938">
                           <label class="govuk-label govuk-checkboxes__label" for="c938">Green technology</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c939" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c939">
                           <label class="govuk-label govuk-checkboxes__label" for="c939">Legacy</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c940" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c940">
                           <label class="govuk-label govuk-checkboxes__label" for="c940">Smarter working</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c941" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c941">
                           <label class="govuk-label govuk-checkboxes__label" for="c941">Cloud strategy</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c942" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c942">
                           <label class="govuk-label govuk-checkboxes__label" for="c942">Job roles and talent acquisition</label>
                         </div>
                       </li>
@@ -6006,19 +6006,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c943" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c943">
                       <label class="govuk-label govuk-checkboxes__label" for="c943">Buying technology</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c944" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c944">
                           <label class="govuk-label govuk-checkboxes__label" for="c944">Digital outcomes and specialists framework</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c945" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c945">
                           <label class="govuk-label govuk-checkboxes__label" for="c945">Digital Marketplace</label>
                         </div>
                       </li>
@@ -6028,37 +6028,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c946" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c946">
                   <label class="govuk-label govuk-checkboxes__label" for="c946">Sustainable development</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c947" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c947">
                   <label class="govuk-label govuk-checkboxes__label" for="c947">Cyber security</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c948" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c948">
                   <label class="govuk-label govuk-checkboxes__label" for="c948">Europe</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c949" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c949">
                       <label class="govuk-label govuk-checkboxes__label" for="c949">European Union laws and regulation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c950" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c950">
                       <label class="govuk-label govuk-checkboxes__label" for="c950">European single market</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c951" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c951">
                       <label class="govuk-label govuk-checkboxes__label" for="c951">European funds</label>
                     </div>
                   </li>
@@ -6066,25 +6066,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c952" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c952">
                   <label class="govuk-label govuk-checkboxes__label" for="c952">Democracy</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c953" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c953">
                       <label class="govuk-label govuk-checkboxes__label" for="c953">Legislative process</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c954" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c954">
                       <label class="govuk-label govuk-checkboxes__label" for="c954">Constitutional affairs</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c955" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c955">
                       <label class="govuk-label govuk-checkboxes__label" for="c955">Voting</label>
                     </div>
                   </li>
@@ -6092,19 +6092,19 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c956" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c956">
                   <label class="govuk-label govuk-checkboxes__label" for="c956">Government reform</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c957" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c957">
                       <label class="govuk-label govuk-checkboxes__label" for="c957">Civil service reform</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c958" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c958">
                       <label class="govuk-label govuk-checkboxes__label" for="c958">Postal service reform</label>
                     </div>
                   </li>
@@ -6114,55 +6114,55 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c959" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c959">
               <label class="govuk-label govuk-checkboxes__label" for="c959">Work</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c960" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c960">
                   <label class="govuk-label govuk-checkboxes__label" for="c960">Secondments with government</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c961" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c961">
                   <label class="govuk-label govuk-checkboxes__label" for="c961">Government graduate schemes</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c962" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c962">
                   <label class="govuk-label govuk-checkboxes__label" for="c962">Self-employment</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c963" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c963">
                       <label class="govuk-label govuk-checkboxes__label" for="c963">Stopping or selling your business</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c964" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c964">
                       <label class="govuk-label govuk-checkboxes__label" for="c964">Paying HMRC</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c965" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c965">
                       <label class="govuk-label govuk-checkboxes__label" for="c965">Managing expenses</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c966" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c966">
                       <label class="govuk-label govuk-checkboxes__label" for="c966">Self Assessment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c967" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c967">
                       <label class="govuk-label govuk-checkboxes__label" for="c967">Tax and National Insurance</label>
                     </div>
                   </li>
@@ -6170,85 +6170,85 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c968" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c968">
                   <label class="govuk-label govuk-checkboxes__label" for="c968">Labour market reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c969" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c969">
                   <label class="govuk-label govuk-checkboxes__label" for="c969">Health and safety reform</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c970" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c970">
                   <label class="govuk-label govuk-checkboxes__label" for="c970">Work and disabled people</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c971" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c971">
                   <label class="govuk-label govuk-checkboxes__label" for="c971">Working, jobs and pensions</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c972" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c972">
                       <label class="govuk-label govuk-checkboxes__label" for="c972">Redundancies, dismissals and disciplinaries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c973" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c973">
                       <label class="govuk-label govuk-checkboxes__label" for="c973">Contracts and working hours</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c974" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c974">
                       <label class="govuk-label govuk-checkboxes__label" for="c974">Workplace bullying and harassment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c975" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c975">
                       <label class="govuk-label govuk-checkboxes__label" for="c975">Your rights at work and trade unions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c976" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c976">
                       <label class="govuk-label govuk-checkboxes__label" for="c976">Workplace and personal pensions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c977" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c977">
                       <label class="govuk-label govuk-checkboxes__label" for="c977">Holidays, time off, sick leave, maternity and paternity leave</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c978" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c978">
                       <label class="govuk-label govuk-checkboxes__label" for="c978">Your pay, tax and the National Minimum Wage</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c979" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c979">
                       <label class="govuk-label govuk-checkboxes__label" for="c979">Finding a job</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c980" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c980">
                       <label class="govuk-label govuk-checkboxes__label" for="c980">Recruiting and hiring</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c981" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c981">
                       <label class="govuk-label govuk-checkboxes__label" for="c981">State Pension</label>
                     </div>
                   </li>
@@ -6256,43 +6256,43 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c982" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c982">
                   <label class="govuk-label govuk-checkboxes__label" for="c982">Payroll</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c983" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c983">
                   <label class="govuk-label govuk-checkboxes__label" for="c983">Pensions and ageing society</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c984" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c984">
                       <label class="govuk-label govuk-checkboxes__label" for="c984">Public service pensions</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c985" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c985">
                       <label class="govuk-label govuk-checkboxes__label" for="c985">Older people</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c986" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c986">
                       <label class="govuk-label govuk-checkboxes__label" for="c986">State Pension age</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c987" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c987">
                       <label class="govuk-label govuk-checkboxes__label" for="c987">State Pension simplification</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c988" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c988">
                       <label class="govuk-label govuk-checkboxes__label" for="c988">Automatic enrolment in workplace pensions</label>
                     </div>
                   </li>
@@ -6300,13 +6300,13 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c989" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c989">
                   <label class="govuk-label govuk-checkboxes__label" for="c989">Trade unions</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c990" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c990">
                   <label class="govuk-label govuk-checkboxes__label" for="c990">Health and safety at work</label>
                 </div>
               </li>
@@ -6314,43 +6314,43 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c991" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c991">
               <label class="govuk-label govuk-checkboxes__label" for="c991">Money</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c992" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c992">
                   <label class="govuk-label govuk-checkboxes__label" for="c992">Expenses and employee benefits</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c993" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c993">
                   <label class="govuk-label govuk-checkboxes__label" for="c993">Court claims, debt and bankruptcy</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c994" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c994">
                   <label class="govuk-label govuk-checkboxes__label" for="c994">Money laundering regulations</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c995" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c995">
                       <label class="govuk-label govuk-checkboxes__label" for="c995">Registration for specific business types</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c996" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c996">
                       <label class="govuk-label govuk-checkboxes__label" for="c996">Problems and compliance checks</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c997" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c997">
                       <label class="govuk-label govuk-checkboxes__label" for="c997">Your role under the regulations</label>
                     </div>
                   </li>
@@ -6358,25 +6358,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c998" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c998">
                   <label class="govuk-label govuk-checkboxes__label" for="c998">Business tax</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c999" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c999">
                       <label class="govuk-label govuk-checkboxes__label" for="c999">Large and mid-size business</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1000" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1000">
                           <label class="govuk-label govuk-checkboxes__label" for="c1000">Large businesses</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1001" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1001">
                           <label class="govuk-label govuk-checkboxes__label" for="c1001">Mid-sized businesses</label>
                         </div>
                       </li>
@@ -6384,55 +6384,55 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1002" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1002">
                       <label class="govuk-label govuk-checkboxes__label" for="c1002">PAYE</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1003" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1003">
                           <label class="govuk-label govuk-checkboxes__label" for="c1003">Statutory pay and leave</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1004" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1004">
                           <label class="govuk-label govuk-checkboxes__label" for="c1004">Special types of employee pay</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1005" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1005">
                           <label class="govuk-label govuk-checkboxes__label" for="c1005">Changes to the business that affect PAYE</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1006" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1006">
                           <label class="govuk-label govuk-checkboxes__label" for="c1006">Employees joining, leaving or changing their circumstances</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1007" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1007">
                           <label class="govuk-label govuk-checkboxes__label" for="c1007">Expenses and benefits</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1008" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1008">
                           <label class="govuk-label govuk-checkboxes__label" for="c1008">Annual PAYE and payroll tasks</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1009" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1009">
                           <label class="govuk-label govuk-checkboxes__label" for="c1009">Paying HMRC</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1010" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1010">
                           <label class="govuk-label govuk-checkboxes__label" for="c1010">Registering and getting started</label>
                         </div>
                       </li>
@@ -6440,31 +6440,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1011" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1011">
                       <label class="govuk-label govuk-checkboxes__label" for="c1011">Life insurance policies</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1012" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1012">
                       <label class="govuk-label govuk-checkboxes__label" for="c1012">IR35: working through an intermediary</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1013" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1013">
                           <label class="govuk-label govuk-checkboxes__label" for="c1013">Employment intermediaries</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1014" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1014">
                           <label class="govuk-label govuk-checkboxes__label" for="c1014">Off-payroll working rules</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1015" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1015">
                           <label class="govuk-label govuk-checkboxes__label" for="c1015">Employment status</label>
                         </div>
                       </li>
@@ -6472,25 +6472,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1016" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1016">
                       <label class="govuk-label govuk-checkboxes__label" for="c1016">Capital allowances</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1017" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1017">
                       <label class="govuk-label govuk-checkboxes__label" for="c1017">Stamp duty on shares</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1018" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1018">
                           <label class="govuk-label govuk-checkboxes__label" for="c1018">Stamp tax on electronic shares</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1019" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1019">
                           <label class="govuk-label govuk-checkboxes__label" for="c1019">Stamp tax on paper shares</label>
                         </div>
                       </li>
@@ -6498,19 +6498,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1020" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1020">
                       <label class="govuk-label govuk-checkboxes__label" for="c1020">Air Passenger Duty</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1021" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1021">
                       <label class="govuk-label govuk-checkboxes__label" for="c1021">Aggregates Levy</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1022" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1022">
                           <label class="govuk-label govuk-checkboxes__label" for="c1022">Payments and reliefs (aggregates levy)</label>
                         </div>
                       </li>
@@ -6518,25 +6518,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1023" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1023">
                       <label class="govuk-label govuk-checkboxes__label" for="c1023">Construction Industry Scheme (CIS)</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1024" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1024">
                           <label class="govuk-label govuk-checkboxes__label" for="c1024">Payments</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1025" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1025">
                           <label class="govuk-label govuk-checkboxes__label" for="c1025">Contractors</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1026" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1026">
                           <label class="govuk-label govuk-checkboxes__label" for="c1026">Subcontractors</label>
                         </div>
                       </li>
@@ -6544,31 +6544,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1027" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1027">
                       <label class="govuk-label govuk-checkboxes__label" for="c1027">Employment related securities</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1028" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1028">
                           <label class="govuk-label govuk-checkboxes__label" for="c1028">SAYE bonus rates</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1029" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1029">
                           <label class="govuk-label govuk-checkboxes__label" for="c1029">National Insurance transfers</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1030" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1030">
                           <label class="govuk-label govuk-checkboxes__label" for="c1030">Asset valuation</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1031" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1031">
                           <label class="govuk-label govuk-checkboxes__label" for="c1031">Returns and notifications</label>
                         </div>
                       </li>
@@ -6576,13 +6576,13 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1032" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1032">
                       <label class="govuk-label govuk-checkboxes__label" for="c1032">Landfill Tax</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1033" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1033">
                           <label class="govuk-label govuk-checkboxes__label" for="c1033">Payments and reliefs (landfill tax)</label>
                         </div>
                       </li>
@@ -6590,43 +6590,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1034" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1034">
                       <label class="govuk-label govuk-checkboxes__label" for="c1034">Gambling duties</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1035" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1035">
                           <label class="govuk-label govuk-checkboxes__label" for="c1035">Paying HMRC</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1036" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1036">
                           <label class="govuk-label govuk-checkboxes__label" for="c1036">General Betting Duty, Pool Betting Duty and Remote Gaming Duty</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1037" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1037">
                           <label class="govuk-label govuk-checkboxes__label" for="c1037">Machine Games Duty</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1038" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1038">
                           <label class="govuk-label govuk-checkboxes__label" for="c1038">Lottery Duty</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1039" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1039">
                           <label class="govuk-label govuk-checkboxes__label" for="c1039">Gaming Duty</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1040" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1040">
                           <label class="govuk-label govuk-checkboxes__label" for="c1040">Bingo Duty</label>
                         </div>
                       </li>
@@ -6634,19 +6634,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1041" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1041">
                       <label class="govuk-label govuk-checkboxes__label" for="c1041">Tobacco Products Duty</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1042" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1042">
                           <label class="govuk-label govuk-checkboxes__label" for="c1042">Payments and reliefs (tobacco products duty)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1043" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1043">
                           <label class="govuk-label govuk-checkboxes__label" for="c1043">Moving and storing goods</label>
                         </div>
                       </li>
@@ -6654,19 +6654,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1044" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1044">
                       <label class="govuk-label govuk-checkboxes__label" for="c1044">Investment schemes</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1045" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1045">
                           <label class="govuk-label govuk-checkboxes__label" for="c1045">Collective Investment Schemes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1046" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1046">
                           <label class="govuk-label govuk-checkboxes__label" for="c1046">Venture capital schemes</label>
                         </div>
                       </li>
@@ -6674,37 +6674,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1047" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1047">
                       <label class="govuk-label govuk-checkboxes__label" for="c1047">Stamp duty and other tax on property</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1048" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1048">
                           <label class="govuk-label govuk-checkboxes__label" for="c1048">Filing a SDLT return</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1049" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1049">
                           <label class="govuk-label govuk-checkboxes__label" for="c1049">Annual Tax on Enveloped Dwellings</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1050" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1050">
                           <label class="govuk-label govuk-checkboxes__label" for="c1050">Stamp Duty before December 2003</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1051" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1051">
                           <label class="govuk-label govuk-checkboxes__label" for="c1051">SDLT on specific transactions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1052" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1052">
                           <label class="govuk-label govuk-checkboxes__label" for="c1052">Pay your SDLT bill</label>
                         </div>
                       </li>
@@ -6712,19 +6712,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1053" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1053">
                       <label class="govuk-label govuk-checkboxes__label" for="c1053">Alcohol duties</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1054" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1054">
                           <label class="govuk-label govuk-checkboxes__label" for="c1054">Payments and reliefs (Alcohol duty)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1055" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1055">
                           <label class="govuk-label govuk-checkboxes__label" for="c1055">Moving and storing goods</label>
                         </div>
                       </li>
@@ -6732,19 +6732,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1056" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1056">
                       <label class="govuk-label govuk-checkboxes__label" for="c1056">Fuel Duty</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1057" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1057">
                           <label class="govuk-label govuk-checkboxes__label" for="c1057">Payments and reliefs (Fuel duty)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1058" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1058">
                           <label class="govuk-label govuk-checkboxes__label" for="c1058">Moving and storing goods</label>
                         </div>
                       </li>
@@ -6752,25 +6752,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1059" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1059">
                       <label class="govuk-label govuk-checkboxes__label" for="c1059">International tax</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1060" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1060">
                           <label class="govuk-label govuk-checkboxes__label" for="c1060">Oil and gas</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1061" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1061">
                           <label class="govuk-label govuk-checkboxes__label" for="c1061">Shipping</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1062" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1062">
                           <label class="govuk-label govuk-checkboxes__label" for="c1062">Double taxation</label>
                         </div>
                       </li>
@@ -6778,43 +6778,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1063" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1063">
                       <label class="govuk-label govuk-checkboxes__label" for="c1063">Corporation Tax</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1064" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1064">
                           <label class="govuk-label govuk-checkboxes__label" for="c1064">Filing your return</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1065" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1065">
                           <label class="govuk-label govuk-checkboxes__label" for="c1065">Changes to your company</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1066" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1066">
                           <label class="govuk-label govuk-checkboxes__label" for="c1066">Payments and refunds</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1067" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1067">
                           <label class="govuk-label govuk-checkboxes__label" for="c1067">Working out your Corporation Tax</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1068" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1068">
                           <label class="govuk-label govuk-checkboxes__label" for="c1068">Reliefs</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1069" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1069">
                           <label class="govuk-label govuk-checkboxes__label" for="c1069">Preparing accounts for Corporation Tax</label>
                         </div>
                       </li>
@@ -6822,37 +6822,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1070" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1070">
                       <label class="govuk-label govuk-checkboxes__label" for="c1070">Pension scheme administration</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1071" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1071">
                           <label class="govuk-label govuk-checkboxes__label" for="c1071">Overseas schemes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1072" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1072">
                           <label class="govuk-label govuk-checkboxes__label" for="c1072">Tax on pensions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1073" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1073">
                           <label class="govuk-label govuk-checkboxes__label" for="c1073">Paying into a pension scheme</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1074" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1074">
                           <label class="govuk-label govuk-checkboxes__label" for="c1074">Administering a pension scheme</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1075" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1075">
                           <label class="govuk-label govuk-checkboxes__label" for="c1075">Pension scheme trustees</label>
                         </div>
                       </li>
@@ -6860,73 +6860,73 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1076" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1076">
                       <label class="govuk-label govuk-checkboxes__label" for="c1076">VAT</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1077" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1077">
                           <label class="govuk-label govuk-checkboxes__label" for="c1077">Rules for particular trades</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1078" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1078">
                           <label class="govuk-label govuk-checkboxes__label" for="c1078">Exporting goods and services</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1079" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1079">
                           <label class="govuk-label govuk-checkboxes__label" for="c1079">Importing goods and services</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1080" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1080">
                           <label class="govuk-label govuk-checkboxes__label" for="c1080">Overseas businesses and UK VAT</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1081" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1081">
                           <label class="govuk-label govuk-checkboxes__label" for="c1081">Charging VAT</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1082" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1082">
                           <label class="govuk-label govuk-checkboxes__label" for="c1082">VAT MOSS</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1083" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1083">
                           <label class="govuk-label govuk-checkboxes__label" for="c1083">Reclaiming VAT on a new home</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1084" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1084">
                           <label class="govuk-label govuk-checkboxes__label" for="c1084">VAT returns</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1085" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1085">
                           <label class="govuk-label govuk-checkboxes__label" for="c1085">Paying</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1086" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1086">
                           <label class="govuk-label govuk-checkboxes__label" for="c1086">Exchange rates</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1087" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1087">
                           <label class="govuk-label govuk-checkboxes__label" for="c1087">Accounting for VAT</label>
                         </div>
                       </li>
@@ -6934,25 +6934,25 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1088" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1088">
                       <label class="govuk-label govuk-checkboxes__label" for="c1088">Business tax reform</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1089" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1089">
                       <label class="govuk-label govuk-checkboxes__label" for="c1089">Climate Change Levy</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1090" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1090">
                       <label class="govuk-label govuk-checkboxes__label" for="c1090">Insurance Premium Tax</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1091" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1091">
                           <label class="govuk-label govuk-checkboxes__label" for="c1091">Paying Insurance Premium Tax</label>
                         </div>
                       </li>
@@ -6962,121 +6962,121 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1092" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1092">
                   <label class="govuk-label govuk-checkboxes__label" for="c1092">Dealing with HMRC</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1093" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1093">
                       <label class="govuk-label govuk-checkboxes__label" for="c1093">Paying HMRC</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1094" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1094">
                           <label class="govuk-label govuk-checkboxes__label" for="c1094">PAYE</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1095" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1095">
                           <label class="govuk-label govuk-checkboxes__label" for="c1095">Payment problems</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1096" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1096">
                           <label class="govuk-label govuk-checkboxes__label" for="c1096">Transport and environmental duties</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1097" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1097">
                           <label class="govuk-label govuk-checkboxes__label" for="c1097">Tax credit overpayments</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1098" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1098">
                           <label class="govuk-label govuk-checkboxes__label" for="c1098">VAT</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1099" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1099">
                           <label class="govuk-label govuk-checkboxes__label" for="c1099">Property taxes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1100" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1100">
                           <label class="govuk-label govuk-checkboxes__label" for="c1100">Shares</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1101" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1101">
                           <label class="govuk-label govuk-checkboxes__label" for="c1101">Pension schemes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1102" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1102">
                           <label class="govuk-label govuk-checkboxes__label" for="c1102">Money laundering regulation fees</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1103" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1103">
                           <label class="govuk-label govuk-checkboxes__label" for="c1103">Insurance Premium Tax</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1104" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1104">
                           <label class="govuk-label govuk-checkboxes__label" for="c1104">Inheritance Tax</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1105" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1105">
                           <label class="govuk-label govuk-checkboxes__label" for="c1105">Gambling duties</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1106" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1106">
                           <label class="govuk-label govuk-checkboxes__label" for="c1106">Income Tax and National Insurance</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1107" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1107">
                           <label class="govuk-label govuk-checkboxes__label" for="c1107">Corporation Tax</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1108" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1108">
                           <label class="govuk-label govuk-checkboxes__label" for="c1108">Construction Industry Scheme (through PAYE)</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1109" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1109">
                           <label class="govuk-label govuk-checkboxes__label" for="c1109">Child Benefit overpayments</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1110" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1110">
                           <label class="govuk-label govuk-checkboxes__label" for="c1110">Alcohol duties</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1111" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1111">
                           <label class="govuk-label govuk-checkboxes__label" for="c1111">Capital Gains Tax</label>
                         </div>
                       </li>
@@ -7084,43 +7084,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1112" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1112">
                       <label class="govuk-label govuk-checkboxes__label" for="c1112">Phishing and scams</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1113" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1113">
                       <label class="govuk-label govuk-checkboxes__label" for="c1113">Shared Workspace service</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1114" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1114">
                       <label class="govuk-label govuk-checkboxes__label" for="c1114">Complaints and appeals</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1115" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1115">
                       <label class="govuk-label govuk-checkboxes__label" for="c1115">Tax avoidance</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1116" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1116">
                           <label class="govuk-label govuk-checkboxes__label" for="c1116">Disguised remuneration schemes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1117" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1117">
                           <label class="govuk-label govuk-checkboxes__label" for="c1117">Disclosing avoidance schemes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1118" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1118">
                           <label class="govuk-label govuk-checkboxes__label" for="c1118">Identifying avoidance schemes</label>
                         </div>
                       </li>
@@ -7128,49 +7128,49 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1119" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1119">
                       <label class="govuk-label govuk-checkboxes__label" for="c1119">Tax compliance</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1120" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1120">
                           <label class="govuk-label govuk-checkboxes__label" for="c1120">International agreements and FATCA</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1121" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1121">
                           <label class="govuk-label govuk-checkboxes__label" for="c1121">Clearances and approvals</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1122" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1122">
                           <label class="govuk-label govuk-checkboxes__label" for="c1122">Disclosing offshore income</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1123" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1123">
                           <label class="govuk-label govuk-checkboxes__label" for="c1123">Reporting tax evasion</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1124" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1124">
                           <label class="govuk-label govuk-checkboxes__label" for="c1124">Non-payment and fraud</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1125" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1125">
                           <label class="govuk-label govuk-checkboxes__label" for="c1125">Disputes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1126" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1126">
                           <label class="govuk-label govuk-checkboxes__label" for="c1126">Compliance checks</label>
                         </div>
                       </li>
@@ -7178,37 +7178,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1127" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1127">
                       <label class="govuk-label govuk-checkboxes__label" for="c1127">Tax agent and adviser guidance</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1128" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1128">
                           <label class="govuk-label govuk-checkboxes__label" for="c1128">Money laundering regulations</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1129" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1129">
                           <label class="govuk-label govuk-checkboxes__label" for="c1129">Working with HMRC - joint initiatives</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1130" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1130">
                           <label class="govuk-label govuk-checkboxes__label" for="c1130">Appeals and penalties</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1131" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1131">
                           <label class="govuk-label govuk-checkboxes__label" for="c1131">Compliance checks</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1132" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1132">
                           <label class="govuk-label govuk-checkboxes__label" for="c1132">Agent authorisation</label>
                         </div>
                       </li>
@@ -7216,31 +7216,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1133" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1133">
                       <label class="govuk-label govuk-checkboxes__label" for="c1133">Software development for HMRC</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1134" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1134">
                           <label class="govuk-label govuk-checkboxes__label" for="c1134">Working in partnership</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1135" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1135">
                           <label class="govuk-label govuk-checkboxes__label" for="c1135">HMRC recognition scheme</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1136" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1136">
                           <label class="govuk-label govuk-checkboxes__label" for="c1136">New to HMRC development</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1137" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1137">
                           <label class="govuk-label govuk-checkboxes__label" for="c1137">Software development support</label>
                         </div>
                       </li>
@@ -7250,37 +7250,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1138" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1138">
                   <label class="govuk-label govuk-checkboxes__label" for="c1138">Personal tax</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1139" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1139">
                       <label class="govuk-label govuk-checkboxes__label" for="c1139">Inheritance Tax</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1140" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1140">
                           <label class="govuk-label govuk-checkboxes__label" for="c1140">Reliefs</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1141" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1141">
                           <label class="govuk-label govuk-checkboxes__label" for="c1141">Paying HMRC</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1142" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1142">
                           <label class="govuk-label govuk-checkboxes__label" for="c1142">Working out the tax</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1143" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1143">
                           <label class="govuk-label govuk-checkboxes__label" for="c1143">Wills and probate</label>
                         </div>
                       </li>
@@ -7288,31 +7288,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1144" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1144">
                       <label class="govuk-label govuk-checkboxes__label" for="c1144">National Insurance</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1145" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1145">
                           <label class="govuk-label govuk-checkboxes__label" for="c1145">Voluntary contributions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1146" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1146">
                           <label class="govuk-label govuk-checkboxes__label" for="c1146">Rates and classes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1147" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1147">
                           <label class="govuk-label govuk-checkboxes__label" for="c1147">Refunds</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1148" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1148">
                           <label class="govuk-label govuk-checkboxes__label" for="c1148">National Insurance numbers</label>
                         </div>
                       </li>
@@ -7320,55 +7320,55 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1149" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1149">
                       <label class="govuk-label govuk-checkboxes__label" for="c1149">Foreign entertainer tax rules</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1150" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1150">
                       <label class="govuk-label govuk-checkboxes__label" for="c1150">Coming to the UK</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1151" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1151">
                       <label class="govuk-label govuk-checkboxes__label" for="c1151">Capital Gains Tax</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1152" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1152">
                           <label class="govuk-label govuk-checkboxes__label" for="c1152">Paying HMRC</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1153" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1153">
                           <label class="govuk-label govuk-checkboxes__label" for="c1153">Divorce and separation</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1154" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1154">
                           <label class="govuk-label govuk-checkboxes__label" for="c1154">Business</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1155" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1155">
                           <label class="govuk-label govuk-checkboxes__label" for="c1155">Shares and investments</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1156" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1156">
                           <label class="govuk-label govuk-checkboxes__label" for="c1156">Property</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1157" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1157">
                           <label class="govuk-label govuk-checkboxes__label" for="c1157">Personal possessions</label>
                         </div>
                       </li>
@@ -7376,49 +7376,49 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1158" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1158">
                       <label class="govuk-label govuk-checkboxes__label" for="c1158">Income Tax</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1159" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1159">
                           <label class="govuk-label govuk-checkboxes__label" for="c1159">Scottish rate of Income Tax</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1160" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1160">
                           <label class="govuk-label govuk-checkboxes__label" for="c1160">Pensions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1161" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1161">
                           <label class="govuk-label govuk-checkboxes__label" for="c1161">Company benefits and share schemes</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1162" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1162">
                           <label class="govuk-label govuk-checkboxes__label" for="c1162">Student jobs and loans</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1163" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1163">
                           <label class="govuk-label govuk-checkboxes__label" for="c1163">Special types of pay</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1164" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1164">
                           <label class="govuk-label govuk-checkboxes__label" for="c1164">Overpayments and underpayments</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1165" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1165">
                           <label class="govuk-label govuk-checkboxes__label" for="c1165">Rates, allowances and reliefs</label>
                         </div>
                       </li>
@@ -7426,37 +7426,37 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1166" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1166">
                       <label class="govuk-label govuk-checkboxes__label" for="c1166">Self Assessment</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1167" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1167">
                           <label class="govuk-label govuk-checkboxes__label" for="c1167">Refunds, appeals and penalties</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1168" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1168">
                           <label class="govuk-label govuk-checkboxes__label" for="c1168">Paying your tax bill</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1169" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1169">
                           <label class="govuk-label govuk-checkboxes__label" for="c1169">Records you must keep</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1170" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1170">
                           <label class="govuk-label govuk-checkboxes__label" for="c1170">Filing a tax return</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1171" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1171">
                           <label class="govuk-label govuk-checkboxes__label" for="c1171">Registering for Self Assessment</label>
                         </div>
                       </li>
@@ -7464,49 +7464,49 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1172" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1172">
                       <label class="govuk-label govuk-checkboxes__label" for="c1172">Non-resident landlord scheme</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1173" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1173">
                       <label class="govuk-label govuk-checkboxes__label" for="c1173">Leaving the UK</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1174" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1174">
                       <label class="govuk-label govuk-checkboxes__label" for="c1174">Trusts</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1175" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1175">
                       <label class="govuk-label govuk-checkboxes__label" for="c1175">Tax on savings and investments</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1176" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1176">
                           <label class="govuk-label govuk-checkboxes__label" for="c1176">Guidance for financial institutions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1177" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1177">
                           <label class="govuk-label govuk-checkboxes__label" for="c1177">Tax efficient savings and investments</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1178" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1178">
                           <label class="govuk-label govuk-checkboxes__label" for="c1178">Tax on shares</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1179" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1179">
                           <label class="govuk-label govuk-checkboxes__label" for="c1179">Tax on savings</label>
                         </div>
                       </li>
@@ -7514,19 +7514,19 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1180" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1180">
                       <label class="govuk-label govuk-checkboxes__label" for="c1180">Living or working abroad or offshore</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1181" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1181">
                           <label class="govuk-label govuk-checkboxes__label" for="c1181">Rules for specific occupations</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1182" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1182">
                           <label class="govuk-label govuk-checkboxes__label" for="c1182">Living and working abroad</label>
                         </div>
                       </li>
@@ -7534,7 +7534,7 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1183" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1183">
                       <label class="govuk-label govuk-checkboxes__label" for="c1183">Personal tax reform</label>
                     </div>
                   </li>
@@ -7542,7 +7542,7 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1184" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1184">
                   <label class="govuk-label govuk-checkboxes__label" for="c1184">Tax evasion and avoidance</label>
                 </div>
               </li>
@@ -7550,55 +7550,55 @@
           </li>
           <li>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" type="checkbox" id="c1185" tabindex="-1">
+              <input class="govuk-checkboxes__input" type="checkbox" id="c1185">
               <label class="govuk-label govuk-checkboxes__label" for="c1185">Business and industry</label>
             </div>
             <ul class="govuk-list">
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1186" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1186">
                   <label class="govuk-label govuk-checkboxes__label" for="c1186">Running a business</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1187" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1187">
                       <label class="govuk-label govuk-checkboxes__label" for="c1187">Business debt and bankruptcy</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1188" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1188">
                       <label class="govuk-label govuk-checkboxes__label" for="c1188">Business licensing</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1189" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1189">
                       <label class="govuk-label govuk-checkboxes__label" for="c1189">Business auditing, accounting and reporting</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1190" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1190">
                       <label class="govuk-label govuk-checkboxes__label" for="c1190">Employing people</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1191" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1191">
                           <label class="govuk-label govuk-checkboxes__label" for="c1191">Dismissing staff and redundancies</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1192" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1192">
                           <label class="govuk-label govuk-checkboxes__label" for="c1192">Payroll</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1193" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1193">
                           <label class="govuk-label govuk-checkboxes__label" for="c1193">Recruiting and hiring</label>
                         </div>
                       </li>
@@ -7606,31 +7606,31 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1194" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1194">
                       <label class="govuk-label govuk-checkboxes__label" for="c1194">Limited companies and partnerships</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1195" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1195">
                           <label class="govuk-label govuk-checkboxes__label" for="c1195">Partnerships</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1196" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1196">
                           <label class="govuk-label govuk-checkboxes__label" for="c1196">Company names</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1197" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1197">
                           <label class="govuk-label govuk-checkboxes__label" for="c1197">Overseas companies and European companies</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1198" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1198">
                           <label class="govuk-label govuk-checkboxes__label" for="c1198">Company closure, administration, liquidation and insolvency</label>
                         </div>
                       </li>
@@ -7638,13 +7638,13 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1199" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1199">
                       <label class="govuk-label govuk-checkboxes__label" for="c1199">Business finance and support</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1200" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1200">
                       <label class="govuk-label govuk-checkboxes__label" for="c1200">Business premises and business rates</label>
                     </div>
                   </li>
@@ -7652,37 +7652,37 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1201" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1201">
                   <label class="govuk-label govuk-checkboxes__label" for="c1201">Corporate governance</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1202" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1202">
                   <label class="govuk-label govuk-checkboxes__label" for="c1202">Business regulation</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1203" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1203">
                       <label class="govuk-label govuk-checkboxes__label" for="c1203">Consumer rights and issues</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1204" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1204">
                           <label class="govuk-label govuk-checkboxes__label" for="c1204">Consumer credit market</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1205" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1205">
                           <label class="govuk-label govuk-checkboxes__label" for="c1205">Gambling regulation</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1206" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1206">
                           <label class="govuk-label govuk-checkboxes__label" for="c1206">Consumer protection</label>
                         </div>
                       </li>
@@ -7690,13 +7690,13 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1207" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1207">
                       <label class="govuk-label govuk-checkboxes__label" for="c1207">Regulation reform</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1208" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1208">
                           <label class="govuk-label govuk-checkboxes__label" for="c1208">Company law reform</label>
                         </div>
                       </li>
@@ -7704,49 +7704,49 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1209" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1209">
                       <label class="govuk-label govuk-checkboxes__label" for="c1209">Sale of goods and services and data protection</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1210" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1210">
                       <label class="govuk-label govuk-checkboxes__label" for="c1210">Energy industry and infrastructure licensing and regulation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1211" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1211">
                       <label class="govuk-label govuk-checkboxes__label" for="c1211">Alcohol licensing</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1212" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1212">
                       <label class="govuk-label govuk-checkboxes__label" for="c1212">Intellectual property</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1213" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1213">
                           <label class="govuk-label govuk-checkboxes__label" for="c1213">Copyright</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1214" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1214">
                           <label class="govuk-label govuk-checkboxes__label" for="c1214">Patents</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1215" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1215">
                           <label class="govuk-label govuk-checkboxes__label" for="c1215">Designs</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1216" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1216">
                           <label class="govuk-label govuk-checkboxes__label" for="c1216">Trade marks</label>
                         </div>
                       </li>
@@ -7754,43 +7754,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1217" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1217">
                       <label class="govuk-label govuk-checkboxes__label" for="c1217">Competition</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1218" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1218">
                           <label class="govuk-label govuk-checkboxes__label" for="c1218">Competition law</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1219" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1219">
                           <label class="govuk-label govuk-checkboxes__label" for="c1219">Regulatory appeals and references</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1220" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1220">
                           <label class="govuk-label govuk-checkboxes__label" for="c1220">Mergers</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1221" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1221">
                           <label class="govuk-label govuk-checkboxes__label" for="c1221">Markets</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1222" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1222">
                           <label class="govuk-label govuk-checkboxes__label" for="c1222">Consumer protection</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1223" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1223">
                           <label class="govuk-label govuk-checkboxes__label" for="c1223">Competition Act and cartels</label>
                         </div>
                       </li>
@@ -7800,31 +7800,31 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1224" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1224">
                   <label class="govuk-label govuk-checkboxes__label" for="c1224">Charities and social enterprises</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1225" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1225">
                       <label class="govuk-label govuk-checkboxes__label" for="c1225">Trustee role and board</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1226" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1226">
                       <label class="govuk-label govuk-checkboxes__label" for="c1226">Fundraising</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1227" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1227">
                       <label class="govuk-label govuk-checkboxes__label" for="c1227">Charity money, tax and accounts</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1228" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1228">
                       <label class="govuk-label govuk-checkboxes__label" for="c1228">Community interest companies</label>
                     </div>
                   </li>
@@ -7832,25 +7832,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1229" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1229">
                   <label class="govuk-label govuk-checkboxes__label" for="c1229">Science and innovation</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1230" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1230">
                       <label class="govuk-label govuk-checkboxes__label" for="c1230">Scientific research and development</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1231" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1231">
                       <label class="govuk-label govuk-checkboxes__label" for="c1231">Research and development</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1232" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1232">
                       <label class="govuk-label govuk-checkboxes__label" for="c1232">Animal research and testing</label>
                     </div>
                   </li>
@@ -7858,49 +7858,49 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1233" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1233">
                   <label class="govuk-label govuk-checkboxes__label" for="c1233">Trade and investment</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1234" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1234">
                       <label class="govuk-label govuk-checkboxes__label" for="c1234">Customs declarations, duties and tariffs (import and export)</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1235" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1235">
                           <label class="govuk-label govuk-checkboxes__label" for="c1235">Commodity codes and reporting</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1236" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1236">
                           <label class="govuk-label govuk-checkboxes__label" for="c1236">Customs Freight Simplified Procedures</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1237" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1237">
                           <label class="govuk-label govuk-checkboxes__label" for="c1237">Rules for specific goods and services</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1238" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1238">
                           <label class="govuk-label govuk-checkboxes__label" for="c1238">UK Trade Tariff and classification of goods</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1239" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1239">
                           <label class="govuk-label govuk-checkboxes__label" for="c1239">Exchange rates</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1240" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1240">
                           <label class="govuk-label govuk-checkboxes__label" for="c1240">Get goods through customs</label>
                         </div>
                       </li>
@@ -7908,43 +7908,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1241" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1241">
                       <label class="govuk-label govuk-checkboxes__label" for="c1241">Free trade</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1242" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1242">
                       <label class="govuk-label govuk-checkboxes__label" for="c1242">Outward investment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1243" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1243">
                       <label class="govuk-label govuk-checkboxes__label" for="c1243">Inward investment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1244" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1244">
                       <label class="govuk-label govuk-checkboxes__label" for="c1244">Importing</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1245" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1245">
                           <label class="govuk-label govuk-checkboxes__label" for="c1245">Import controls</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1246" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1246">
                           <label class="govuk-label govuk-checkboxes__label" for="c1246">Wood packaging</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1247" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1247">
                           <label class="govuk-label govuk-checkboxes__label" for="c1247">Commodity codes and reporting</label>
                         </div>
                       </li>
@@ -7952,43 +7952,43 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1248" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1248">
                       <label class="govuk-label govuk-checkboxes__label" for="c1248">Trade barriers</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1249" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1249">
                       <label class="govuk-label govuk-checkboxes__label" for="c1249">Exporting</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1250" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1250">
                           <label class="govuk-label govuk-checkboxes__label" for="c1250">Embargoes and sanctions</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1251" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1251">
                           <label class="govuk-label govuk-checkboxes__label" for="c1251">Export finance</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1252" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1252">
                           <label class="govuk-label govuk-checkboxes__label" for="c1252">Export controls and licensing</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1253" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1253">
                           <label class="govuk-label govuk-checkboxes__label" for="c1253">Licences and special rules</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1254" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1254">
                           <label class="govuk-label govuk-checkboxes__label" for="c1254">Trade restrictions on exports</label>
                         </div>
                       </li>
@@ -7996,7 +7996,7 @@
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1255" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1255">
                       <label class="govuk-label govuk-checkboxes__label" for="c1255">Digital trade</label>
                     </div>
                   </li>
@@ -8004,49 +8004,49 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1256" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1256">
                   <label class="govuk-label govuk-checkboxes__label" for="c1256">Manufacturing</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1257" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1257">
                   <label class="govuk-label govuk-checkboxes__label" for="c1257">UK economy</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1258" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1258">
                       <label class="govuk-label govuk-checkboxes__label" for="c1258">Regional growth fund</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1259" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1259">
                       <label class="govuk-label govuk-checkboxes__label" for="c1259">City deals and growth deals</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1260" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1260">
                       <label class="govuk-label govuk-checkboxes__label" for="c1260">UK economic growth</label>
                     </div>
                     <ul class="govuk-list">
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1261" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1261">
                           <label class="govuk-label govuk-checkboxes__label" for="c1261">Economic development in coastal and seaside areas</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1262" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1262">
                           <label class="govuk-label govuk-checkboxes__label" for="c1262">Local Enterprise Partnerships (LEPs) and Enterprise Zones</label>
                         </div>
                       </li>
                       <li>
                         <div class="govuk-checkboxes__item">
-                          <input class="govuk-checkboxes__input" type="checkbox" id="c1263" tabindex="-1">
+                          <input class="govuk-checkboxes__input" type="checkbox" id="c1263">
                           <label class="govuk-label govuk-checkboxes__label" for="c1263">Management of the European Regional Development Fund</label>
                         </div>
                       </li>
@@ -8056,25 +8056,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1264" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1264">
                   <label class="govuk-label govuk-checkboxes__label" for="c1264">Industrial strategy</label>
                 </div>
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1265" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1265">
                   <label class="govuk-label govuk-checkboxes__label" for="c1265">Business and the environment</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1266" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1266">
                       <label class="govuk-label govuk-checkboxes__label" for="c1266">Energy demand reduction</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1267" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1267">
                       <label class="govuk-label govuk-checkboxes__label" for="c1267">UK energy security</label>
                     </div>
                   </li>
@@ -8082,25 +8082,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1268" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1268">
                   <label class="govuk-label govuk-checkboxes__label" for="c1268">Media and communications</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1269" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1269">
                       <label class="govuk-label govuk-checkboxes__label" for="c1269">Media and creative industries</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1270" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1270">
                       <label class="govuk-label govuk-checkboxes__label" for="c1270">Broadband investment</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1271" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1271">
                       <label class="govuk-label govuk-checkboxes__label" for="c1271">Communications and telecomms</label>
                     </div>
                   </li>
@@ -8108,25 +8108,25 @@
               </li>
               <li>
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" type="checkbox" id="c1272" tabindex="-1">
+                  <input class="govuk-checkboxes__input" type="checkbox" id="c1272">
                   <label class="govuk-label govuk-checkboxes__label" for="c1272">Financial services</label>
                 </div>
                 <ul class="govuk-list">
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1273" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1273">
                       <label class="govuk-label govuk-checkboxes__label" for="c1273">Financial services regulation</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1274" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1274">
                       <label class="govuk-label govuk-checkboxes__label" for="c1274">Access to financial services</label>
                     </div>
                   </li>
                   <li>
                     <div class="govuk-checkboxes__item">
-                      <input class="govuk-checkboxes__input" type="checkbox" id="c1275" tabindex="-1">
+                      <input class="govuk-checkboxes__input" type="checkbox" id="c1275">
                       <label class="govuk-label govuk-checkboxes__label" for="c1275">Bank regulation</label>
                     </div>
                   </li>

--- a/examples/miller-columns-test.html
+++ b/examples/miller-columns-test.html
@@ -19,7 +19,7 @@
     <ul id="taxonomy" class="govuk-list">
     <li>
        <div class="govuk-checkboxes__item">
-          <input type="checkbox" id="topic-206b7f3a-49b5-476f-af0f-fd27e2a68473" class="govuk-checkboxes__input" name="topics[]" value="206b7f3a-49b5-476f-af0f-fd27e2a68473" tabindex="-1">
+          <input type="checkbox" id="topic-206b7f3a-49b5-476f-af0f-fd27e2a68473" class="govuk-checkboxes__input" name="topics[]" value="206b7f3a-49b5-476f-af0f-fd27e2a68473">
           <label for="topic-206b7f3a-49b5-476f-af0f-fd27e2a68473" class="govuk-label govuk-checkboxes__label">
           Parenting, childcare and children's services
           </label>
@@ -27,7 +27,7 @@
        <ul class="govuk-list">
           <li>
              <div class="govuk-checkboxes__item">
-                <input type="checkbox" id="topic-1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" class="govuk-checkboxes__input" name="topics[]" value="1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" tabindex="-1" checked>
+                <input type="checkbox" id="topic-1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" class="govuk-checkboxes__input" name="topics[]" value="1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" checked>
                 <label for="topic-1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" class="govuk-label govuk-checkboxes__label">
                 Divorce, separation and legal issues
                 </label>
@@ -35,7 +35,7 @@
              <ul class="govuk-list">
                 <li>
                    <div class="govuk-checkboxes__item">
-                      <input type="checkbox" id="topic-9ed56732-8600-493e-8467-295233529718" class="govuk-checkboxes__input" name="topics[]" value="9ed56732-8600-493e-8467-295233529718" tabindex="-1">
+                      <input type="checkbox" id="topic-9ed56732-8600-493e-8467-295233529718" class="govuk-checkboxes__input" name="topics[]" value="9ed56732-8600-493e-8467-295233529718">
                       <label for="topic-9ed56732-8600-493e-8467-295233529718" class="govuk-label govuk-checkboxes__label">
                       Child custody
                       </label>
@@ -43,7 +43,7 @@
                 </li>
                 <li>
                    <div class="govuk-checkboxes__item">
-                      <input type="checkbox" id="topic-237b2e72-c465-42fe-9293-8b6af21713c0" class="govuk-checkboxes__input" name="topics[]" value="237b2e72-c465-42fe-9293-8b6af21713c0" tabindex="-1">
+                      <input type="checkbox" id="topic-237b2e72-c465-42fe-9293-8b6af21713c0" class="govuk-checkboxes__input" name="topics[]" value="237b2e72-c465-42fe-9293-8b6af21713c0">
                       <label for="topic-237b2e72-c465-42fe-9293-8b6af21713c0" class="govuk-label govuk-checkboxes__label">
                       Disagreements about parentage
                       </label>
@@ -53,7 +53,7 @@
           </li>
           <li>
              <div class="govuk-checkboxes__item">
-                <input type="checkbox" id="topic-f1d9c348-5c5e-4fc6-9172-13a62537d3ae" class="govuk-checkboxes__input" name="topics[]" value="f1d9c348-5c5e-4fc6-9172-13a62537d3ae" tabindex="-1">
+                <input type="checkbox" id="topic-f1d9c348-5c5e-4fc6-9172-13a62537d3ae" class="govuk-checkboxes__input" name="topics[]" value="f1d9c348-5c5e-4fc6-9172-13a62537d3ae">
                 <label for="topic-f1d9c348-5c5e-4fc6-9172-13a62537d3ae" class="govuk-label govuk-checkboxes__label">
                 Childcare and early years
                 </label>
@@ -61,7 +61,7 @@
              <ul class="govuk-list">
                 <li>
                    <div class="govuk-checkboxes__item">
-                      <input type="checkbox" id="topic-1da1c700-cef8-45c4-9bb7-11a4b0003e10" class="govuk-checkboxes__input" name="topics[]" value="1da1c700-cef8-45c4-9bb7-11a4b0003e10" tabindex="-1">
+                      <input type="checkbox" id="topic-1da1c700-cef8-45c4-9bb7-11a4b0003e10" class="govuk-checkboxes__input" name="topics[]" value="1da1c700-cef8-45c4-9bb7-11a4b0003e10">
                       <label for="topic-1da1c700-cef8-45c4-9bb7-11a4b0003e10" class="govuk-label govuk-checkboxes__label">
                       Local authorities and early years
                       </label>

--- a/index.js
+++ b/index.js
@@ -129,6 +129,8 @@ class Topic {
         let childList = item.querySelector('ul')
         childList = childList instanceof HTMLUListElement ? childList : null
 
+        checkbox.tabIndex = -1
+
         const previous = index > 0 ? topics[index - 1] : null
 
         const topic = new Topic(label, checkbox, childList, parent, previous)

--- a/test/test.js
+++ b/test/test.js
@@ -338,6 +338,12 @@ describe('miller-columns', function() {
       assert.equal(millerColumnsItem.getAttribute('aria-describedby'), describedbyId)
     })
 
+    it('adds each item to the tab order', function() {
+      const millerColumnsItem = document.querySelector('.miller-columns__item')
+
+      assert.equal(millerColumnsItem.getAttribute('tabindex'), '0')
+    })
+
     it('removes checkboxes from the focus order', function() {
       const item = document.querySelector('ul li')
       const itemCheckbox = item.querySelector('input')

--- a/test/test.js
+++ b/test/test.js
@@ -28,7 +28,7 @@ describe('miller-columns', function() {
           <ul id="taxonomy">
           <li>
              <div class="govuk-checkboxes__item">
-                <input type="checkbox" id="topic-206b7f3a-49b5-476f-af0f-fd27e2a68473" class="govuk-checkboxes__input" name="topics[]" value="206b7f3a-49b5-476f-af0f-fd27e2a68473" tabindex="-1">
+                <input type="checkbox" id="topic-206b7f3a-49b5-476f-af0f-fd27e2a68473" class="govuk-checkboxes__input" name="topics[]" value="206b7f3a-49b5-476f-af0f-fd27e2a68473">
                 <label for="topic-206b7f3a-49b5-476f-af0f-fd27e2a68473" class="govuk-label govuk-checkboxes__label" id="parenting-childcare-and-childrens-services">
                 Parenting, childcare and children's services
                 </label>
@@ -36,7 +36,7 @@ describe('miller-columns', function() {
              <ul>
                 <li>
                    <div class="govuk-checkboxes__item">
-                      <input type="checkbox" id="topic-1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" class="govuk-checkboxes__input" name="topics[]" value="1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" tabindex="-1">
+                      <input type="checkbox" id="topic-1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" class="govuk-checkboxes__input" name="topics[]" value="1423ec9f-d62c-40f7-b10e-a2bdf020d8b7">
                       <label for="topic-1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" class="govuk-label govuk-checkboxes__label" id="divorce-separation-and-legal-issues">
                       Divorce, separation and legal issues
                       </label>
@@ -44,7 +44,7 @@ describe('miller-columns', function() {
                    <ul>
                       <li>
                          <div class="govuk-checkboxes__item">
-                            <input type="checkbox" id="topic-9ed56732-8600-493e-8467-295233529718" class="govuk-checkboxes__input" name="topics[]" value="9ed56732-8600-493e-8467-295233529718" tabindex="-1">
+                            <input type="checkbox" id="topic-9ed56732-8600-493e-8467-295233529718" class="govuk-checkboxes__input" name="topics[]" value="9ed56732-8600-493e-8467-295233529718">
                             <label for="topic-9ed56732-8600-493e-8467-295233529718" class="govuk-label govuk-checkboxes__label" id="child-custody">
                             Child custody
                             </label>
@@ -52,7 +52,7 @@ describe('miller-columns', function() {
                       </li>
                       <li>
                          <div class="govuk-checkboxes__item">
-                            <input type="checkbox" id="topic-237b2e72-c465-42fe-9293-8b6af21713c0" class="govuk-checkboxes__input" name="topics[]" value="237b2e72-c465-42fe-9293-8b6af21713c0" tabindex="-1">
+                            <input type="checkbox" id="topic-237b2e72-c465-42fe-9293-8b6af21713c0" class="govuk-checkboxes__input" name="topics[]" value="237b2e72-c465-42fe-9293-8b6af21713c0">
                             <label for="topic-237b2e72-c465-42fe-9293-8b6af21713c0" class="govuk-label govuk-checkboxes__label" id="disagreements-about-parentage">
                             Disagreements about parentage
                             </label>
@@ -62,7 +62,7 @@ describe('miller-columns', function() {
                 </li>
                 <li>
                    <div class="govuk-checkboxes__item">
-                      <input type="checkbox" id="topic-f1d9c348-5c5e-4fc6-9172-13a62537d3ae" class="govuk-checkboxes__input" name="topics[]" value="f1d9c348-5c5e-4fc6-9172-13a62537d3ae" tabindex="-1">
+                      <input type="checkbox" id="topic-f1d9c348-5c5e-4fc6-9172-13a62537d3ae" class="govuk-checkboxes__input" name="topics[]" value="f1d9c348-5c5e-4fc6-9172-13a62537d3ae">
                       <label for="topic-f1d9c348-5c5e-4fc6-9172-13a62537d3ae" class="govuk-label govuk-checkboxes__label">
                       Childcare and early years
                       </label>
@@ -70,7 +70,7 @@ describe('miller-columns', function() {
                    <ul>
                       <li>
                          <div class="govuk-checkboxes__item">
-                            <input type="checkbox" id="topic-1da1c700-cef8-45c4-9bb7-11a4b0003e10" class="govuk-checkboxes__input" name="topics[]" value="1da1c700-cef8-45c4-9bb7-11a4b0003e10" tabindex="-1">
+                            <input type="checkbox" id="topic-1da1c700-cef8-45c4-9bb7-11a4b0003e10" class="govuk-checkboxes__input" name="topics[]" value="1da1c700-cef8-45c4-9bb7-11a4b0003e10">
                             <label for="topic-1da1c700-cef8-45c4-9bb7-11a4b0003e10" class="govuk-label govuk-checkboxes__label">
                             Local authorities and early years
                             </label>
@@ -82,7 +82,7 @@ describe('miller-columns', function() {
           </li>
           <li>
              <div class="govuk-checkboxes__item">
-                <input type="checkbox" id="topic-206b7f3a-49b5-476f-af0f-fd27e2a68474" class="govuk-checkboxes__input" name="topics[]" value="206b7f3a-49b5-476f-af0f-fd27e2a68474" tabindex="-1">
+                <input type="checkbox" id="topic-206b7f3a-49b5-476f-af0f-fd27e2a68474" class="govuk-checkboxes__input" name="topics[]" value="206b7f3a-49b5-476f-af0f-fd27e2a68474">
                 <label for="topic-206b7f3a-49b5-476f-af0f-fd27e2a68474" class="govuk-label govuk-checkboxes__label">
                 Corporate information
                 </label>
@@ -337,6 +337,13 @@ describe('miller-columns', function() {
 
       assert.equal(millerColumnsItem.getAttribute('aria-describedby'), describedbyId)
     })
+
+    it('removes checkboxes from the focus order', function() {
+      const item = document.querySelector('ul li')
+      const itemCheckbox = item.querySelector('input')
+
+      assert.equal(itemCheckbox.getAttribute('tabindex'), '-1')
+    })
   })
 
   describe('when loading pre-selected items', function() {
@@ -348,7 +355,7 @@ describe('miller-columns', function() {
           <ul id="taxonomy">
           <li>
              <div class="govuk-checkboxes__item">
-                <input type="checkbox" id="topic-206b7f3a-49b5-476f-af0f-fd27e2a68473" class="govuk-checkboxes__input" name="topics[]" value="206b7f3a-49b5-476f-af0f-fd27e2a68473" tabindex="-1">
+                <input type="checkbox" id="topic-206b7f3a-49b5-476f-af0f-fd27e2a68473" class="govuk-checkboxes__input" name="topics[]" value="206b7f3a-49b5-476f-af0f-fd27e2a68473">
                 <label for="topic-206b7f3a-49b5-476f-af0f-fd27e2a68473" class="govuk-label govuk-checkboxes__label">
                 Parenting, childcare and children's services
                 </label>
@@ -356,7 +363,7 @@ describe('miller-columns', function() {
              <ul>
                 <li>
                    <div class="govuk-checkboxes__item">
-                      <input type="checkbox" id="topic-1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" class="govuk-checkboxes__input" name="topics[]" value="1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" tabindex="-1" checked>
+                      <input type="checkbox" id="topic-1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" class="govuk-checkboxes__input" name="topics[]" value="1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" checked>
                       <label for="topic-1423ec9f-d62c-40f7-b10e-a2bdf020d8b7" class="govuk-label govuk-checkboxes__label">
                       Divorce, separation and legal issues
                       </label>
@@ -364,7 +371,7 @@ describe('miller-columns', function() {
                    <ul>
                       <li>
                          <div class="govuk-checkboxes__item">
-                            <input type="checkbox" id="topic-9ed56732-8600-493e-8467-295233529718" class="govuk-checkboxes__input" name="topics[]" value="9ed56732-8600-493e-8467-295233529718" tabindex="-1">
+                            <input type="checkbox" id="topic-9ed56732-8600-493e-8467-295233529718" class="govuk-checkboxes__input" name="topics[]" value="9ed56732-8600-493e-8467-295233529718">
                             <label for="topic-9ed56732-8600-493e-8467-295233529718" class="govuk-label govuk-checkboxes__label">
                             Child custody
                             </label>
@@ -372,7 +379,7 @@ describe('miller-columns', function() {
                       </li>
                       <li>
                          <div class="govuk-checkboxes__item">
-                            <input type="checkbox" id="topic-237b2e72-c465-42fe-9293-8b6af21713c0" class="govuk-checkboxes__input" name="topics[]" value="237b2e72-c465-42fe-9293-8b6af21713c0" tabindex="-1">
+                            <input type="checkbox" id="topic-237b2e72-c465-42fe-9293-8b6af21713c0" class="govuk-checkboxes__input" name="topics[]" value="237b2e72-c465-42fe-9293-8b6af21713c0">
                             <label for="topic-237b2e72-c465-42fe-9293-8b6af21713c0" class="govuk-label govuk-checkboxes__label">
                             Disagreements about parentage
                             </label>
@@ -382,7 +389,7 @@ describe('miller-columns', function() {
                 </li>
                 <li>
                    <div class="govuk-checkboxes__item">
-                      <input type="checkbox" id="topic-f1d9c348-5c5e-4fc6-9172-13a62537d3ae" class="govuk-checkboxes__input" name="topics[]" value="f1d9c348-5c5e-4fc6-9172-13a62537d3ae" tabindex="-1">
+                      <input type="checkbox" id="topic-f1d9c348-5c5e-4fc6-9172-13a62537d3ae" class="govuk-checkboxes__input" name="topics[]" value="f1d9c348-5c5e-4fc6-9172-13a62537d3ae">
                       <label for="topic-f1d9c348-5c5e-4fc6-9172-13a62537d3ae" class="govuk-label govuk-checkboxes__label">
                       Childcare and early years
                       </label>
@@ -390,7 +397,7 @@ describe('miller-columns', function() {
                    <ul>
                       <li>
                          <div class="govuk-checkboxes__item">
-                            <input type="checkbox" id="topic-1da1c700-cef8-45c4-9bb7-11a4b0003e10" class="govuk-checkboxes__input" name="topics[]" value="1da1c700-cef8-45c4-9bb7-11a4b0003e10" tabindex="-1">
+                            <input type="checkbox" id="topic-1da1c700-cef8-45c4-9bb7-11a4b0003e10" class="govuk-checkboxes__input" name="topics[]" value="1da1c700-cef8-45c4-9bb7-11a4b0003e10">
                             <label for="topic-1da1c700-cef8-45c4-9bb7-11a4b0003e10" class="govuk-label govuk-checkboxes__label">
                             Local authorities and early years
                             </label>


### PR DESCRIPTION
If we set the `tabindex` to `-1` in markup (as we did in the examples presented in this repository) the users that have JavaScript disabled will not be able to reach them using keyboard-based or landmark navigation. Instead, if we set them via JavaScript (which is what this PR proposes) [we then have the miller-columns items added to the focus order](https://github.com/alphagov/miller-columns-element/blob/master/index.js#L432) and [the checkboxes removed from the focus order](https://github.com/alphagov/miller-columns-element/compare/remove-checkboxes-from-focus-order?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR132).

Providing only one focusable element for each topic fixes [a problem we encounter in IE11](https://trello.com/c/YaeoN3JE), where the checkbox state and the miller-column items can become out of sync.