### PR TITLE
Update to govuk-frontend 3.7.0

### DIFF
--- a/dist/main.css
+++ b/dist/main.css
@@ -293,6 +293,12 @@
     .govuk-list--number > li {
       margin-bottom: 5px; } }
 
+.govuk-list--spaced > li {
+  margin-bottom: 10px; }
+  @media (min-width: 40.0625em) {
+    .govuk-list--spaced > li {
+      margin-bottom: 15px; } }
+
 .govuk-template {
   background-color: #f3f2f1;
   -webkit-text-size-adjust: 100%;
@@ -1218,27 +1224,36 @@
         color: #000000; } }
 
 .govuk-back-link[href] {
-  border-bottom: 1px solid #0b0c0c;
-  text-decoration: none; }
+  text-decoration: underline; }
   .govuk-back-link[href]:focus {
-    border-bottom-color: transparent; }
+    text-decoration: none; }
+    .govuk-back-link[href]:focus:before {
+      border-color: #0b0c0c; }
 
 .govuk-back-link:before {
-  display: block;
-  width: 0;
-  height: 0;
-  border-style: solid;
-  border-color: transparent;
-  -webkit-clip-path: polygon(0% 50%, 100% 100%, 100% 0%);
-  clip-path: polygon(0% 50%, 100% 100%, 100% 0%);
-  border-width: 5px 6px 5px 0;
-  border-right-color: inherit;
   content: "";
+  display: block;
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 0;
-  margin: auto; }
+  left: 3px;
+  width: 7px;
+  height: 7px;
+  margin: auto 0;
+  -webkit-transform: rotate(225deg);
+  -ms-transform: rotate(225deg);
+  transform: rotate(225deg);
+  border: solid;
+  border-width: 1px 1px 0 0;
+  border-color: #626a6e; }
+
+.govuk-back-link:after {
+  content: "";
+  position: absolute;
+  top: -14px;
+  right: 0;
+  bottom: -14px;
+  left: 0; }
 
 .govuk-visually-hidden {
   position: absolute !important;
@@ -1358,6 +1373,19 @@
     @media print {
       .govuk-breadcrumbs__link:link, .govuk-breadcrumbs__link:visited, .govuk-breadcrumbs__link:hover, .govuk-breadcrumbs__link:active, .govuk-breadcrumbs__link:focus {
         color: #000000; } }
+
+@media (max-width: 40.0525em) {
+  .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list-item {
+    display: none; }
+    .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list-item:first-child, .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list-item:last-child {
+      display: inline-block; }
+    .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list-item:before {
+      top: 6px;
+      margin: 0; }
+  .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex; } }
 
 .miller-columns-selected {
   margin-bottom: 20px;
@@ -1624,10 +1652,9 @@
   padding-top: 0;
   padding-right: 0;
   padding-bottom: 0;
-  border-top: 0;
-  border-right: 0;
-  border-left: 0;
-  background: transparent; }
+  border: 0;
+  background: transparent;
+  text-decoration: underline; }
   @media (min-width: 40.0625em) {
     .miller-columns .govuk-back-link {
       display: none; } }

--- a/dist/miller-columns.css
+++ b/dist/miller-columns.css
@@ -879,27 +879,36 @@
         color: #000000; } }
 
 .govuk-back-link[href] {
-  border-bottom: 1px solid #0b0c0c;
-  text-decoration: none; }
+  text-decoration: underline; }
   .govuk-back-link[href]:focus {
-    border-bottom-color: transparent; }
+    text-decoration: none; }
+    .govuk-back-link[href]:focus:before {
+      border-color: #0b0c0c; }
 
 .govuk-back-link:before {
-  display: block;
-  width: 0;
-  height: 0;
-  border-style: solid;
-  border-color: transparent;
-  -webkit-clip-path: polygon(0% 50%, 100% 100%, 100% 0%);
-  clip-path: polygon(0% 50%, 100% 100%, 100% 0%);
-  border-width: 5px 6px 5px 0;
-  border-right-color: inherit;
   content: "";
+  display: block;
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 0;
-  margin: auto; }
+  left: 3px;
+  width: 7px;
+  height: 7px;
+  margin: auto 0;
+  -webkit-transform: rotate(225deg);
+  -ms-transform: rotate(225deg);
+  transform: rotate(225deg);
+  border: solid;
+  border-width: 1px 1px 0 0;
+  border-color: #626a6e; }
+
+.govuk-back-link:after {
+  content: "";
+  position: absolute;
+  top: -14px;
+  right: 0;
+  bottom: -14px;
+  left: 0; }
 
 .govuk-visually-hidden {
   position: absolute !important;
@@ -1019,6 +1028,19 @@
     @media print {
       .govuk-breadcrumbs__link:link, .govuk-breadcrumbs__link:visited, .govuk-breadcrumbs__link:hover, .govuk-breadcrumbs__link:active, .govuk-breadcrumbs__link:focus {
         color: #000000; } }
+
+@media (max-width: 40.0525em) {
+  .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list-item {
+    display: none; }
+    .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list-item:first-child, .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list-item:last-child {
+      display: inline-block; }
+    .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list-item:before {
+      top: 6px;
+      margin: 0; }
+  .govuk-breadcrumbs--collapse-on-mobile .govuk-breadcrumbs__list {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex; } }
 
 .miller-columns-selected {
   margin-bottom: 20px;
@@ -1285,10 +1307,9 @@
   padding-top: 0;
   padding-right: 0;
   padding-bottom: 0;
-  border-top: 0;
-  border-right: 0;
-  border-left: 0;
-  background: transparent; }
+  border: 0;
+  background: transparent;
+  text-decoration: underline; }
   @media (min-width: 40.0625em) {
     .miller-columns .govuk-back-link {
       display: none; } }

--- a/miller-columns.scss
+++ b/miller-columns.scss
@@ -195,10 +195,9 @@ $mc-active-item-background: govuk-colour("blue");
     padding-top: 0;
     padding-right: 0;
     padding-bottom: 0;
-    border-top: 0;
-    border-right: 0;
-    border-left: 0;
+    border: 0;
     background: transparent;
+    text-decoration: underline;
 
     @include govuk-media-query($from: tablet) {
       display: none;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4404,7 +4404,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
@@ -6084,7 +6084,7 @@
       "dependencies": {
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -6652,7 +6652,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -8439,7 +8439,7 @@
         },
         "acorn-jsx": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
           "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
           "dev": true,
           "requires": {
@@ -8448,7 +8448,7 @@
           "dependencies": {
             "acorn": {
               "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
               "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
               "dev": true
             }
@@ -8497,7 +8497,7 @@
         },
         "eslint": {
           "version": "2.13.1",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+          "resolved": "http://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
           "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
           "dev": true,
           "requires": {
@@ -8538,7 +8538,7 @@
         },
         "espree": {
           "version": "3.5.4",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+          "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
           "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
           "dev": true,
           "requires": {
@@ -8586,7 +8586,7 @@
         },
         "inquirer": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true,
           "requires": {
@@ -8616,13 +8616,13 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
         "progress": {
           "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "resolved": "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
           "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
           "dev": true
         },
@@ -8647,7 +8647,7 @@
         },
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         },
@@ -8670,7 +8670,7 @@
         },
         "table": {
           "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+          "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
           "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint": "^7.2.0",
     "eslint-plugin-github": "1.6.0",
     "flow-bin": "^0.127.0",
-    "govuk-frontend": "^3.6.0",
+    "govuk-frontend": "^3.7.0",
     "karma": "^5.0.1",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.0",


### PR DESCRIPTION
This change is intended to be a temporary fix for a style leakage issue, caused by unsynchronized dependency on `govuk-frontend` (`miller-columns-element` in 3.6.0 and `content-publisher` in 3.7.0), by updating this repo to the latest version.

A proper fix should follow this PR by either scoping the `govuk-frontend` component styles (checkboxes, back-link, breadcrumbs) used in this repo or by making the `miller-columns-element` non-dependent on other components, leaving the required styles to only be imported in the project using it (e.g. `content-publisher`).

Back link in Content Publisher
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="64" alt="Screenshot 2020-06-19 at 18 01 53" src="https://user-images.githubusercontent.com/788096/85161951-6e8fb780-b258-11ea-83a5-a16bfccd8830.png">

</td><td valign="top">

<img width="67" alt="Screenshot 2020-06-19 at 18 04 10" src="https://user-images.githubusercontent.com/788096/85161968-74859880-b258-11ea-9200-4fdb6e8211c8.png">


</td></tr>
</table>
