### PR TITLE
Release 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 1.3.2
+
+- Fix back-link styles by updating miller-columns-element to `govuk-frontend` 3.7 (PR #75)
+
 ## 1.3.1
 
 - Ensure checkboxes are focusable without JS (PR #35)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "miller-columns-element",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miller-columns-element",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Miller columns (cascading lists) for hierarchical topic selection on GOV.UK taxonomy",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
## 1.3.2

- Fix back-link styles by updating miller-columns-element to `govuk-frontend` 3.7.0 (PR #75)