### PR TITLE
Copy dist files into examples directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+examples/dist

--- a/examples/checkboxes-checked.html
+++ b/examples/checkboxes-checked.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>miller-columns examples</title>
-  <link href="../dist/examples.css" rel="stylesheet">
+  <link href="dist/examples.css" rel="stylesheet">
   <script src="https://unpkg.com/element-closest/browser"></script>
   <script src="https://unpkg.com/core-js-bundle/index.js"></script>
   <script src="https://unpkg.com/@webcomponents/custom-elements/custom-elements.min.js"></script>
@@ -8138,6 +8138,6 @@
       </miller-columns>
     </main>
   </div>
-  <script src="../dist/index.umd.js"></script>
+  <script src="dist/index.umd.js"></script>
 </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>miller-columns examples</title>
-  <link href="../dist/examples.css" rel="stylesheet">
+  <link href="dist/examples.css" rel="stylesheet">
   <script src="https://unpkg.com/element-closest/browser"></script>
   <script src="https://unpkg.com/core-js-bundle/index.js"></script>
   <script src="https://unpkg.com/@webcomponents/custom-elements/custom-elements.min.js"></script>
@@ -8138,6 +8138,6 @@
       </miller-columns>
     </main>
   </div>
-  <script src="../dist/index.umd.js"></script>
+  <script src="dist/index.umd.js"></script>
 </body>
 </html>

--- a/examples/miller-columns-test.html
+++ b/examples/miller-columns-test.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>govuk-miller-columns examples</title>
-  <link href="../dist/miller-columns.css" rel="stylesheet">
+  <link href="dist/miller-columns.css" rel="stylesheet">
   <script src="https://unpkg.com/element-closest/browser"></script>
   <script src="https://unpkg.com/core-js-bundle/index.js"></script>
   <script src="https://unpkg.com/@webcomponents/custom-elements/custom-elements.min.js"></script>
@@ -73,6 +73,6 @@
     </li>
     </ul>
   </miller-columns>
-  <script src="../dist/index.umd.js"></script>
+  <script src="dist/index.umd.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "build-css": "node-sass examples.scss dist/examples.css && node-sass miller-columns.scss dist/miller-columns.css",
     "build-umd": "BABEL_ENV=umd babel index.js -o dist/index.umd.js",
     "build-esm": "BABEL_ENV=esm babel index.js -o dist/index.esm.js",
-    "build": "npm run build-css && npm run build-umd && npm run build-esm",
+    "build-examples": "rm -rf examples/dist && cp -r dist examples/dist",
+    "build": "npm run build-css && npm run build-umd && npm run build-esm && npm run build-examples",
     "pretest": "npm run build && npm run lint",
     "test": "karma start test/karma.config.js",
     "watch": "npm-watch"


### PR DESCRIPTION
This allows the directory examples to be rendered without requiring
contents from the rest of this repo. This change allows GitHub pages to
work properly as they won't support a relative link down a directory.

This directory is ignored from git since it is generated. Ideally the
other dist directory in this repo would be git ignored too, but
resolving this is beyond this commit's scope.