### PR TITLE
Upgrade `eslint-plugin-relay` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "miller-columns-element",
       "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
@@ -15,6 +16,7 @@
         "chai": "^4.2.0",
         "eslint": "^7.2.0",
         "eslint-plugin-github": "1.6.0",
+        "eslint-plugin-relay": "^1.8.3",
         "flow-bin": "^0.133.0",
         "govuk-frontend": "^4.0.0",
         "karma": "^6.0.0",
@@ -3457,12 +3459,12 @@
       }
     },
     "node_modules/eslint-plugin-relay": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-relay/-/eslint-plugin-relay-1.7.0.tgz",
-      "integrity": "sha512-JmAMQFr9CxXFLo5BppdN/sleofrE1J/cERIgkFqnYdTq0KAeUNGnz3jO41cqcp1y92/D+KJdmEKFsPfnqnDByQ==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-relay/-/eslint-plugin-relay-1.8.3.tgz",
+      "integrity": "sha512-awyrwntUTZ7Z+lJUnniTCnJdZYr1dY2djQDARMx1P1y2BFMsBjtTljBK0lBEM7yiTHPBwVnE2OSnXxcD4yMb0A==",
       "dev": true,
       "dependencies": {
-        "graphql": "^14.0.0 | ^15.0.0-rc.1"
+        "graphql": "^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/eslint-rule-documentation": {
@@ -4837,9 +4839,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "15.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.0.0-rc.2.tgz",
-      "integrity": "sha512-X9ZybETBiZ5zndyXm/Yn3dd0nJqiCNZ7w06lnd0zMiCtBR/KQGgxJmnf47Y/P/Fy7JXM4QDF+MeeoH724yc3DQ==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "dev": true,
       "engines": {
         "node": ">= 10.x"
@@ -15107,12 +15109,12 @@
       }
     },
     "eslint-plugin-relay": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-relay/-/eslint-plugin-relay-1.7.0.tgz",
-      "integrity": "sha512-JmAMQFr9CxXFLo5BppdN/sleofrE1J/cERIgkFqnYdTq0KAeUNGnz3jO41cqcp1y92/D+KJdmEKFsPfnqnDByQ==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-relay/-/eslint-plugin-relay-1.8.3.tgz",
+      "integrity": "sha512-awyrwntUTZ7Z+lJUnniTCnJdZYr1dY2djQDARMx1P1y2BFMsBjtTljBK0lBEM7yiTHPBwVnE2OSnXxcD4yMb0A==",
       "dev": true,
       "requires": {
-        "graphql": "^14.0.0 | ^15.0.0-rc.1"
+        "graphql": "^14.0.0 || ^15.0.0"
       }
     },
     "eslint-rule-documentation": {
@@ -15936,8 +15938,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "https://registry.npmjs.org/graphql/-/graphql-15.0.0-rc.2.tgz",
-      "integrity": "sha512-X9ZybETBiZ5zndyXm/Yn3dd0nJqiCNZ7w06lnd0zMiCtBR/KQGgxJmnf47Y/P/Fy7JXM4QDF+MeeoH724yc3DQ==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "dev": true
     },
     "graphql-config": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "chai": "^4.2.0",
     "eslint": "^7.2.0",
     "eslint-plugin-github": "1.6.0",
+    "eslint-plugin-relay": "^1.8.3",
     "flow-bin": "^0.133.0",
     "govuk-frontend": "^4.0.0",
     "karma": "^6.0.0",


### PR DESCRIPTION
## Description 

The build on main is currently failing. This is due to a conflict in the package.json.lockfile caused by `eslint-plugin-relay` requiring a version of GraphQL that is no longer supported by NPM. Adding the latest version resolves the issue.

This will allow us to continue to update the dependencies.