### PR TITLE
Update docs with deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## DEPRECATION
+
+- This module was created to support the Miller Columns at gov.uk/browse which we have removed. This module is no longer needed. (PR #264)
+
 ## 2.0.0
 
 - BREAKING: govuk-frontend classes are no longer bundled with this module, apps using this are expected to already be using `govuk-frontend` (PR #97)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> # ⚠️ This repo is no longer supported ⚠️
+> This module was created to support the Miller Columns at gov.uk/browse which we have removed. This module is no longer needed.
+
 # &lt;miller-columns&gt; element
 
 Express a hierarchy by showing selectable lists of the items in each hierarchy level.


### PR DESCRIPTION
This module was created to support the Miller Columns at gov.uk/browse which we have removed [1][2]. This module is no longer needed. 

[Trello](https://trello.com/c/zfQRmVIt/10-deprecate-and-archive-the-miller-columns-code-repo)

[1] https://github.com/alphagov/collections/pull/2865
[2] https://github.com/alphagov/collections/pull/2945