### PR TITLE
Add "position: sticky" to the miller columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Browsers without native [custom element support][support] require a [polyfill][]
 - Chrome
 - Firefox
 - Safari
-- Internet Explorer 11
 - Microsoft Edge
+- Internet Explorer 11 (Functional)
 
 [support]: https://caniuse.com/#feat=custom-elementsv1
 [polyfill]: https://github.com/webcomponents/custom-elements

--- a/miller-columns.scss
+++ b/miller-columns.scss
@@ -37,6 +37,8 @@ $mc-active-item-background: govuk-colour("blue");
   display: none;
   width: 100%;
   height: 100%;
+  position: sticky;
+  top: 0;
   vertical-align: top;
   white-space: normal;
   transition-duration: $mc-transition-time;


### PR DESCRIPTION
In longer lists the children of the item of a miller column element are sometimes not visible when you click on it. Using `position: sticky` ensures that they are displayed on screen when possible.

## Before
https://user-images.githubusercontent.com/9594455/210401714-a8fb1fac-4ca6-47f4-a03c-e8eab3247347.mov

## After
https://user-images.githubusercontent.com/9594455/210401729-a4d0af56-b8ac-44bf-a691-dbded31348ff.mov

https://trello.com/c/YJ8n9Hc9/1097-add-position-sticky-to-miller-columns
