### PR TITLE
Pin to Node v20 to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: lts/*
+          node-version: 20
           cache: npm
       - run: npm ci
       - run: npm run test
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: lts/*
+          node-version: 20
           cache: npm
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci


### PR DESCRIPTION
See #343 where pinning to v20 and v21 were contrasted.

From v21 onwards, we get:

```
npm WARN deprecated @npmcli/move-file@2.0.1: This functionality has been moved to @npmcli/fs
npm ERR! code 1
npm ERR! path /home/runner/work/miller-columns-element/miller-columns-element/node_modules/node-sass
npm ERR! command failed
npm ERR! command sh -c node scripts/build.js
npm ERR! Binary found at /home/runner/work/miller-columns-element/miller-columns-element/node_modules/node-sass/vendor/linux-x64-120/binding.node
npm ERR! Testing binary
npm ERR! Binary has a problem: Error: /home/runner/work/miller-columns-element/miller-columns-element/node_modules/node-sass/vendor/linux-x64-120/binding.node: file too short
npm ERR!     at Module._extensions..node (node:internal/modules/cjs/loader:1464:18)
npm ERR!     at Module.load (node:internal/modules/cjs/loader:1205:32)
npm ERR!     at Module._load (node:internal/modules/cjs/loader:1021:12)
npm ERR!     at Module.require (node:internal/modules/cjs/loader:1230:19)
npm ERR!     at require (node:internal/modules/helpers:179:18)
npm ERR!     at module.exports (/home/runner/work/miller-columns-element/miller-columns-element/node_modules/node-sass/lib/binding.js:19:10)
npm ERR!     at Object.<anonymous> (/home/runner/work/miller-columns-element/miller-columns-element/node_modules/node-sass/lib/index.js:13:35)
npm ERR!     at Module._compile (node:internal/modules/cjs/loader:1368:14)
npm ERR!     at Module._extensions..js (node:internal/modules/cjs/loader:1426:10)
npm ERR!     at Module.load (node:internal/modules/cjs/loader:1205:32) {
npm ERR!   code: 'ERR_DLOPEN_FAILED'
npm ERR! }
npm ERR! Building the binary locally
```