### PR TITLE
Deprecate miller-columns-element as a standalone repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,44 +1,7 @@
 version: 2
 updates:
 - package-ecosystem: npm
-  directory: "/"
-  dependency-type: production
+  directory: /
   schedule:
     interval: daily
-    time: "03:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: eslint-plugin-github
-    versions:
-    - "> 1.6.0"
-  - dependency-name: flow-bin
-    versions:
-    - "> 0.133.0, < 1"
-  - dependency-name: flow-bin
-    versions:
-    - ">= 0.145.a, < 0.146"
-  - dependency-name: y18n
-    versions:
-    - 4.0.1
-    - 4.0.2
-    - 4.0.3
-  - dependency-name: eslint
-    versions:
-    - 7.19.0
-    - 7.21.0
-    - 7.23.0
-  - dependency-name: karma
-    versions:
-    - 6.0.3
-    - 6.0.4
-    - 6.1.0
-    - 6.1.2
-    - 6.3.0
-    - 6.3.1
-  - dependency-name: mocha
-    versions:
-    - 8.3.1
-  - dependency-name: chai
-    versions:
-    - 4.3.1
-    - 4.3.3
+  open-pull-requests-limit: 0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# &lt;miller-columns&gt; element
+# &lt;miller-columns&gt; element (DEPRECATED)
+
+> **NOTE**: This project is deprecated and is [planned to be migrated into Whitehall](https://gov-uk.atlassian.net/browse/WHIT-2438).
+---
 
 Express a hierarchy by showing selectable lists of the items in each hierarchy level.
 


### PR DESCRIPTION
We intend to [migrate miller-columns-element into Whitehall](https://gov-uk.atlassian.net/browse/WHIT-2438) and will likely take the opportunity to [fundamentally rewrite the component](https://gov-uk.atlassian.net/browse/WHIT-2439) to behave more like a standard GOV.UK component (i.e. not a web native 'custom element' and all the overhead that requires).

As per [GOV.UK's policy on updating dependencies for deprecated repos](https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#deprecated-repos), we're disabling Dependabot updates for its dependencies, with the exception of security updates.